### PR TITLE
build: 릴리즈한 지 7일 미만인 패키지는 사용하지 않도록 설정

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.48",
     "uvicorn[standard]>=0.42.0",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
최근 대두된 axios, LiteLLM 등의 보안 이슈로 인해 릴리즈한 지 7일 미만인 패키지는 사용하지 않도록 설정함.

Lock 파일을 다시 생성해야 할 수도 있음.