### PR TITLE
Kamis API 실시간 시세

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,5 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/farmos
 CORS_ORIGINS=["http://localhost:5173","http://localhost:3000"]
 SOIL_MOISTURE_LOW=55.0
 SOIL_MOISTURE_HIGH=70.0
+KAMIS_API_KEY=
+KAMIS_CERT_ID=

--- a/backend/app/api/market.py
+++ b/backend/app/api/market.py
@@ -1,0 +1,59 @@
+"""농산물 시세 (KAMIS) API 라우터."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from httpx import HTTPError
+
+from app.core.deps import get_current_user
+from app.services.kamis import kamis_service
+
+router = APIRouter(prefix="/market", tags=["market"])
+
+
+@router.get("/latest", dependencies=[Depends(get_current_user)])
+async def get_latest_prices(
+    product_cls_code: str = Query("", description="01:소매, 02:도매, 빈값:전체"),
+    item_category_code: str = Query("", description="부류코드 (빈값=전체)"),
+    country_code: str = Query("", description="지역코드 (빈값=전국평균)"),
+) -> dict:
+    """일별 부류별 도·소매가격정보 (API #1 dailySalesList)."""
+    try:
+        items = await kamis_service.get_latest_prices(
+            product_cls_code=product_cls_code,
+            item_category_code=item_category_code,
+            country_code=country_code,
+        )
+        return {"items": items}
+    except HTTPError:
+        raise HTTPException(502, "KAMIS API 연결에 실패했습니다.")
+    except Exception:
+        raise HTTPException(502, "KAMIS 응답 형식이 올바르지 않습니다.")
+
+
+@router.get("/daily", dependencies=[Depends(get_current_user)])
+async def get_daily_prices(
+    start_date: str = Query(..., description="시작일 (YYYY-MM-DD)"),
+    end_date: str = Query(..., description="종료일 (YYYY-MM-DD)"),
+    item_code: str = Query(..., description="품목코드"),
+    kind_code: str = Query(..., description="품종코드"),
+    rank_code: str = Query("1", description="등급코드"),
+    product_cls_code: str = Query("01", description="01:소매, 02:도매"),
+    item_category_code: str = Query("", description="부류코드"),
+    county_code: str = Query("", description="지역코드"),
+) -> dict:
+    """일별 품목별 도·소매가격정보 (API #2 periodProductList)."""
+    try:
+        data = await kamis_service.get_daily_prices(
+            start_date=start_date,
+            end_date=end_date,
+            item_code=item_code,
+            kind_code=kind_code,
+            rank_code=rank_code,
+            product_cls_code=product_cls_code,
+            item_category_code=item_category_code,
+            county_code=county_code,
+        )
+        return data
+    except HTTPError:
+        raise HTTPException(502, "KAMIS API 연결에 실패했습니다.")
+    except Exception:
+        raise HTTPException(502, "KAMIS 응답 형식이 올바르지 않습니다.")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     KMA_ENCODING_KEY: str = ""
     KMA_DECODING_KEY: str = ""
 
+    # KAMIS (농산물유통정보 API)
+    KAMIS_API_KEY: str = ""
+    KAMIS_CERT_ID: str = ""
+
     # OpenRouter API
     OPENROUTER_API_KEY: str = ""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import select
 
-from app.api import auth, health, irrigation, knowledge, sensors
+from app.api import auth, health, irrigation, knowledge, market, sensors
 from app.core.config import settings
 from app.core.database import async_session, close_db, init_db
 from app.core.security import hash_password
@@ -79,3 +79,4 @@ app.include_router(health.router, prefix=settings.API_V1_PREFIX)
 app.include_router(sensors.router, prefix=settings.API_V1_PREFIX)
 app.include_router(irrigation.router, prefix=settings.API_V1_PREFIX)
 app.include_router(knowledge.router, prefix=settings.API_V1_PREFIX)
+app.include_router(market.router, prefix=settings.API_V1_PREFIX)

--- a/backend/app/schemas/market.py
+++ b/backend/app/schemas/market.py
@@ -1,0 +1,61 @@
+"""KAMIS 시세 API 응답 스키마."""
+
+from pydantic import BaseModel
+
+
+class MarketItemPrice(BaseModel):
+    """API #6 — 최근일자 가격 항목 하나."""
+
+    item_name: str = ""
+    item_code: str = ""
+    kind_name: str = ""
+    kind_code: str = ""
+    rank: str = ""
+    rank_code: str = ""
+    unit: str = ""
+    day1: str = ""  # 당일
+    dpr1: str = ""  # 당일 가격
+    day2: str = ""  # 1일 전
+    dpr2: str = ""  # 1일 전 가격
+    day3: str = ""  # 1주일 전
+    dpr3: str = ""  # 1주일 전 가격
+    day4: str = ""  # 2주일 전
+    dpr4: str = ""  # 2주일 전 가격
+    day5: str = ""  # 1개월 전
+    dpr5: str = ""  # 1개월 전 가격
+    day6: str = ""  # 1년 전
+    dpr6: str = ""  # 1년 전 가격
+    day7: str = ""
+    dpr7: str = ""
+
+
+class LatestPricesResponse(BaseModel):
+    items: list[MarketItemPrice]
+
+
+class PriceTrendPoint(BaseModel):
+    """API #7 — 날짜별 가격 데이터 포인트."""
+
+    date: str = ""
+    price: str = ""
+
+
+class TrendsResponse(BaseModel):
+    item_name: str = ""
+    kind_name: str = ""
+    unit: str = ""
+    prices: list[dict] = []
+
+
+class DailyPriceRecord(BaseModel):
+    """API #2 — 일별 가격 레코드."""
+
+    date: str = ""
+    price: str = ""
+
+
+class DailyPricesResponse(BaseModel):
+    item_name: str = ""
+    kind_name: str = ""
+    unit: str = ""
+    records: list[dict] = []

--- a/backend/app/services/kamis.py
+++ b/backend/app/services/kamis.py
@@ -1,0 +1,139 @@
+"""KAMIS (농산물유통정보) API 클라이언트 서비스."""
+
+from __future__ import annotations
+
+import httpx
+
+from app.core.config import settings
+
+
+class KamisService:
+    """KAMIS Open API wrapper.
+
+    Endpoints used:
+      #1  dailySalesList      — 일별 부류별 도·소매가격정보 (메인)
+      #2  periodProductList   — 일별 품목별 도·소매가격정보 (상세)
+    """
+
+    BASE_URL = "https://www.kamis.or.kr/service/price/xml.do"
+    TIMEOUT = 15  # seconds
+
+    def __init__(self, api_key: str, cert_id: str) -> None:
+        self._api_key = api_key
+        self._cert_id = cert_id
+
+    # ── helpers ──────────────────────────────────────────────
+
+    def _common_params(self) -> dict[str, str]:
+        return {
+            "p_cert_key": self._api_key,
+            "p_cert_id": self._cert_id,
+            "p_returntype": "json",
+        }
+
+    async def _get(self, action: str, extra: dict[str, str] | None = None) -> dict:
+        params = {"action": action, **self._common_params(), **(extra or {})}
+        async with httpx.AsyncClient(timeout=self.TIMEOUT) as client:
+            resp = await client.get(self.BASE_URL, params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+    # ── API #1: 일별 부류별 도·소매가격정보 ─────────────────
+
+    async def get_latest_prices(
+        self,
+        *,
+        product_cls_code: str = "",
+        item_category_code: str = "",
+        country_code: str = "",
+    ) -> list[dict]:
+        """최신 가격 목록을 반환한다.
+
+        Returns a flat list of item dicts, each containing:
+          product_cls_code, category_code, category_name, productno,
+          item_name, unit, day1, dpr1, day2, dpr2, day3, dpr3, day4, dpr4,
+          direction, value
+        """
+        raw = await self._get(
+            "dailySalesList",
+            {
+                "p_product_cls_code": product_cls_code,
+                "p_item_category_code": item_category_code,
+                "p_country_code": country_code,
+            },
+        )
+        return self._extract_daily_sales(raw)
+
+    # ── API #2: 일별 품목별 도·소매가격정보 ─────────────────
+
+    async def get_daily_prices(
+        self,
+        start_date: str,
+        end_date: str,
+        item_code: str,
+        kind_code: str,
+        rank_code: str = "1",
+        *,
+        product_cls_code: str = "01",
+        item_category_code: str = "",
+        county_code: str = "",
+        convert_kg: str = "Y",
+    ) -> dict:
+        """일별 가격 데이터를 반환한다."""
+        raw = await self._get(
+            "periodProductList",
+            {
+                "p_productclscode": product_cls_code,
+                "p_startday": start_date,
+                "p_endday": end_date,
+                "p_itemcategorycode": item_category_code,
+                "p_itemcode": item_code,
+                "p_kindcode": kind_code,
+                "p_productrankcode": rank_code,
+                "p_countycode": county_code,
+                "p_convert_kg_yn": convert_kg,
+            },
+        )
+        return self._extract_daily_data(raw)
+
+    # ── response normalizers ────────────────────────────────
+
+    @staticmethod
+    def _extract_daily_sales(raw: dict) -> list[dict]:
+        """dailySalesList 응답에서 가격 항목 리스트를 추출."""
+        try:
+            items = raw.get("price", [])
+            if isinstance(items, dict):
+                items = [items]
+            return items if isinstance(items, list) else []
+        except (AttributeError, TypeError):
+            return []
+
+    @staticmethod
+    def _extract_daily_data(raw: dict) -> dict:
+        """periodProductList 응답을 정규화."""
+        try:
+            price_data = raw.get("data", {})
+
+            # error response: {"data": ["001"]}
+            if isinstance(price_data, list):
+                return {"item_name": "", "kind_name": "", "unit": "", "records": []}
+
+            items = price_data.get("item", [])
+            if isinstance(items, dict):
+                items = [items]
+
+            return {
+                "item_name": items[0].get("itemname", "") if items else "",
+                "kind_name": items[0].get("kindname", "") if items else "",
+                "unit": items[0].get("unit", "") if items else "",
+                "records": items if isinstance(items, list) else [],
+            }
+        except (AttributeError, TypeError, IndexError):
+            return {"item_name": "", "kind_name": "", "unit": "", "records": []}
+
+
+kamis_service = KamisService(
+    api_key=settings.KAMIS_API_KEY,
+    cert_id=settings.KAMIS_CERT_ID,
+)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "asyncpg>=0.31.0",
     "chromadb>=1.5.5",
     "fastapi>=0.135.2",
+    "httpx>=0.28.0",
     "passlib[bcrypt]>=1.7.4",
     "pydantic-settings>=2.13.1",
     "python-dotenv>=1.2.2",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-26T06:36:06.8653809Z"
+exclude-newer = "2026-03-31T04:49:47.1685114Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -455,6 +455,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "chromadb" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -469,6 +470,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "chromadb", specifier = ">=1.5.5" },
     { name = "fastapi", specifier = ">=0.135.2" },
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -2104,4 +2106,3 @@ sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50e
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import DocumentsPage from '@/modules/documents/DocumentsPage';
 import WeatherPage from '@/modules/weather/WeatherPage';
 import HarvestPage from '@/modules/harvest/HarvestPage';
 import JournalPage from '@/modules/journal/JournalPage';
+import MarketPricePage from '@/modules/market/MarketPricePage';
 import ScenarioPage from '@/pages/ScenarioPage';
 import LoginPage from '@/modules/auth/LoginPage';
 import SignupPage from '@/modules/auth/SignupPage';
@@ -66,6 +67,7 @@ export default function App() {
               <Route path="weather" element={<WeatherPage />} />
               <Route path="harvest" element={<HarvestPage />} />
               <Route path="journal" element={<JournalPage />} />
+              <Route path="market" element={<MarketPricePage />} />
               <Route path="scenario" element={<ScenarioPage />} />
             </Route>
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -13,6 +13,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/weather': '기상 연동 스케줄링',
   '/harvest': '수확량 예측',
   '/journal': '영농일지',
+  '/market': '농산물 시세 정보',
   '/scenario': '사과 농장 한 달 시나리오',
 };
 

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -15,6 +15,7 @@ const MORE_TABS = [
   { to: '/documents', icon: '/images/icons/documents.jpg', label: '행정 서류' },
   { to: '/harvest', icon: '/images/icons/harvest.jpg', label: '수확 예측' },
   { to: '/journal', icon: '/images/icons/journal.jpg', label: '영농일지' },
+  { to: '/market', icon: '/images/icons/harvest.jpg', label: '시세 정보' },
   { to: '/scenario', icon: '/images/icons/scenario.jpg', label: '시나리오' },
 ];
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { to: '/weather', icon: '/images/icons/weather.jpg', label: '기상 스케줄' },
   { to: '/harvest', icon: '/images/icons/harvest.jpg', label: '수확 예측' },
   { to: '/journal', icon: '/images/icons/journal.jpg', label: '영농일지' },
+  { to: '/market', icon: '/images/icons/harvest.jpg', label: '시세 정보' },
   { to: '/scenario', icon: '/images/icons/scenario.jpg', label: '시나리오' },
 ];
 

--- a/frontend/src/hooks/useMarketData.ts
+++ b/frontend/src/hooks/useMarketData.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from 'react';
+import type { KamisItemPrice } from '@/types';
+
+const API_BASE = 'http://localhost:8000/api/v1';
+
+interface MarketData {
+  latestPrices: KamisItemPrice[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useMarketData() {
+  const [data, setData] = useState<MarketData>({
+    latestPrices: [],
+    loading: false,
+    error: null,
+  });
+
+  const fetchLatest = useCallback(async (productClsCode = '') => {
+    setData(prev => ({ ...prev, loading: true, error: null }));
+    try {
+      const params = new URLSearchParams();
+      if (productClsCode) params.set('product_cls_code', productClsCode);
+      const res = await fetch(
+        `${API_BASE}/market/latest?${params}`,
+        { credentials: 'include' },
+      );
+      if (!res.ok) throw new Error(`${res.status}`);
+      const json = await res.json();
+      setData(prev => ({ ...prev, latestPrices: json.items ?? [], loading: false }));
+    } catch (err) {
+      setData(prev => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : '시세 정보를 불러올 수 없습니다.',
+      }));
+    }
+  }, []);
+
+  return { ...data, fetchLatest };
+}

--- a/frontend/src/modules/market/MarketPricePage.tsx
+++ b/frontend/src/modules/market/MarketPricePage.tsx
@@ -1,0 +1,269 @@
+import { useState, useEffect, useMemo } from 'react';
+import { MdTrendingUp, MdTrendingDown, MdShowChart, MdWarningAmber } from 'react-icons/md';
+import { useMarketData } from '@/hooks/useMarketData';
+import type { KamisItemPrice, ImportantChange } from '@/types';
+
+// ── 가격 문자열 파싱 ───────────────────────────────────
+function parseKamisPrice(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw === 'number') return raw;
+  if (typeof raw !== 'string') return null;
+  if (!raw || raw === '-' || raw.trim() === '') return null;
+  const num = parseInt(raw.replace(/,/g, ''), 10);
+  return Number.isNaN(num) ? null : num;
+}
+
+// ── 주요 변동 감지 임계값 ──────────────────────────────
+const DAILY_CHANGE_THRESHOLD = 5;   // %
+const WEEKLY_CHANGE_THRESHOLD = 10; // %
+
+function detectImportantChanges(items: KamisItemPrice[]): ImportantChange[] {
+  const changes: ImportantChange[] = [];
+
+  for (const item of items) {
+    const current = parseKamisPrice(item.dpr1);
+    const yesterday = parseKamisPrice(item.dpr2);
+    const weekAgo = parseKamisPrice(item.dpr3);
+
+    if (current == null || current === 0) continue;
+
+    let isImportant = false;
+    let changePercent = 0;
+    let previousPrice = 0;
+
+    // 전일 대비 변동
+    if (yesterday != null && yesterday !== 0) {
+      changePercent = ((current - yesterday) / yesterday) * 100;
+      previousPrice = yesterday;
+      if (Math.abs(changePercent) >= DAILY_CHANGE_THRESHOLD) {
+        isImportant = true;
+      }
+    }
+
+    // 1주일 전 대비 변동
+    if (!isImportant && weekAgo != null && weekAgo !== 0) {
+      const weekChange = ((current - weekAgo) / weekAgo) * 100;
+      if (Math.abs(weekChange) >= WEEKLY_CHANGE_THRESHOLD) {
+        isImportant = true;
+        changePercent = weekChange;
+        previousPrice = weekAgo;
+      }
+    }
+
+    if (isImportant) {
+      changes.push({
+        item_name: item.item_name,
+        productno: item.productno,
+        category_name: item.category_name,
+        unit: item.unit,
+        currentPrice: current,
+        previousPrice,
+        changePercent,
+        direction: changePercent > 0 ? 'up' : 'down',
+      });
+    }
+  }
+
+  return changes.sort((a, b) => Math.abs(b.changePercent) - Math.abs(a.changePercent));
+}
+
+export default function MarketPricePage() {
+  const { latestPrices, loading, error, fetchLatest } = useMarketData();
+  const [productCls, setProductCls] = useState<'' | '01' | '02'>('01');
+  const [categoryFilter, setCategoryFilter] = useState<string>('');
+
+  useEffect(() => { fetchLatest(productCls); }, [fetchLatest, productCls]);
+
+  const importantChanges = useMemo(() => detectImportantChanges(latestPrices), [latestPrices]);
+
+  // 부류별 카테고리 목록 추출
+  const categories = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of latestPrices) {
+      if (item.category_code && item.category_name) {
+        map.set(item.category_code, item.category_name);
+      }
+    }
+    return Array.from(map.entries());
+  }, [latestPrices]);
+
+  // 필터링된 가격 목록
+  const filteredPrices = useMemo(() => {
+    if (!categoryFilter) return latestPrices;
+    return latestPrices.filter(item => item.category_code === categoryFilter);
+  }, [latestPrices, categoryFilter]);
+
+  // ── 로딩 / 에러 ────────────────────────────────────────
+  if (loading && latestPrices.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary/10 text-primary text-2xl mb-3 animate-pulse">
+            <MdShowChart />
+          </div>
+          <p className="text-gray-500">시세 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && latestPrices.length === 0) {
+    return (
+      <div className="card bg-red-50 border-red-200">
+        <div className="flex items-center gap-3">
+          <MdWarningAmber className="text-2xl text-danger" />
+          <div>
+            <p className="font-semibold text-gray-900">시세 정보를 불러올 수 없습니다</p>
+            <p className="text-sm text-gray-600 mt-1">{error}</p>
+          </div>
+        </div>
+        <button onClick={() => fetchLatest(productCls)} className="btn-primary mt-4 text-sm">
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* ── 소매/도매 토글 ─────────────────────────────── */}
+      <div className="flex items-center gap-2">
+        {([['01', '소매가격'], ['02', '도매가격']] as const).map(([code, label]) => (
+          <button
+            key={code}
+            onClick={() => setProductCls(code)}
+            className={`px-4 py-2 rounded-xl text-sm font-medium transition ${
+              productCls === code
+                ? 'bg-primary text-white'
+                : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── 주요 가격 변동 알림 ──────────────────────── */}
+      <div className={`card ${importantChanges.length > 0 ? 'bg-gradient-to-r from-amber-50 to-orange-50 border-amber-200' : 'bg-gradient-to-r from-green-50 to-emerald-50 border-green-200'}`}>
+        <div className="flex items-center gap-2 mb-3">
+          <MdWarningAmber className={`text-xl ${importantChanges.length > 0 ? 'text-amber-500' : 'text-success'}`} />
+          <h3 className="section-title">주요 가격 변동</h3>
+          <span className="text-xs text-gray-400 ml-auto">전일 대비 {DAILY_CHANGE_THRESHOLD}% 이상 또는 전주 대비 {WEEKLY_CHANGE_THRESHOLD}% 이상</span>
+        </div>
+
+        {importantChanges.length === 0 ? (
+          <p className="text-sm text-gray-600">오늘은 큰 가격 변동이 없습니다.</p>
+        ) : (
+          <div className="space-y-2">
+            {importantChanges.slice(0, 10).map((c, i) => (
+              <div key={i} className="flex items-center justify-between p-3 bg-white/70 rounded-xl">
+                <div className="flex items-center gap-2">
+                  {c.direction === 'up'
+                    ? <MdTrendingUp className="text-lg text-danger" />
+                    : <MdTrendingDown className="text-lg text-success" />}
+                  <span className="font-medium text-gray-800">{c.item_name}</span>
+                  <span className="text-xs text-gray-400">{c.category_name}</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-gray-500">
+                    {c.previousPrice.toLocaleString()} → {c.currentPrice.toLocaleString()}원/{c.unit}
+                  </span>
+                  <span className={`badge ${c.direction === 'up' ? 'badge-danger' : 'badge-success'}`}>
+                    {c.direction === 'up' ? '+' : ''}{c.changePercent.toFixed(1)}%
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── 부류 필터 ────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => setCategoryFilter('')}
+          className={`px-3 py-1.5 rounded-lg text-sm transition ${
+            !categoryFilter ? 'bg-primary text-white' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
+          }`}
+        >
+          전체
+        </button>
+        {categories.map(([code, name]) => (
+          <button
+            key={code}
+            onClick={() => setCategoryFilter(code)}
+            className={`px-3 py-1.5 rounded-lg text-sm transition ${
+              categoryFilter === code ? 'bg-primary text-white' : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
+            }`}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+
+      {/* ── 가격 목록 테이블 ─────────────────────────── */}
+      <div className="card">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="section-title">
+            {productCls === '01' ? '소매' : '도매'} 가격 현황
+          </h3>
+          <span className="text-xs text-gray-400">{filteredPrices.length}개 품목</span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="text-left py-3 px-4 font-semibold text-gray-600">품목</th>
+                <th className="text-center py-3 px-4 font-semibold text-gray-600">단위</th>
+                <th className="text-right py-3 px-4 font-semibold text-gray-600">당일</th>
+                <th className="text-right py-3 px-4 font-semibold text-gray-600">1일전</th>
+                <th className="text-right py-3 px-4 font-semibold text-gray-600">1주전</th>
+                <th className="text-right py-3 px-4 font-semibold text-gray-600">1개월전</th>
+                <th className="text-center py-3 px-4 font-semibold text-gray-600">등락</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredPrices.map((item, idx) => {
+                const cur = parseKamisPrice(item.dpr1);
+                const prev = parseKamisPrice(item.dpr2);
+                const diff = cur != null && prev != null && prev !== 0
+                  ? ((cur - prev) / prev * 100)
+                  : null;
+
+                return (
+                  <tr key={idx} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="py-3 px-4">
+                      <span className="font-medium">{item.item_name}</span>
+                    </td>
+                    <td className="text-center py-3 px-4 text-gray-400">{item.unit}</td>
+                    <td className="text-right py-3 px-4 font-semibold">
+                      {item.dpr1 || '-'}
+                    </td>
+                    <td className="text-right py-3 px-4 text-gray-500">{item.dpr2 || '-'}</td>
+                    <td className="text-right py-3 px-4 text-gray-500">{item.dpr3 || '-'}</td>
+                    <td className="text-right py-3 px-4 text-gray-500">{item.dpr4 || '-'}</td>
+                    <td className="text-center py-3 px-4">
+                      {diff != null ? (
+                        <span className={`inline-flex items-center gap-0.5 text-xs font-medium ${
+                          diff > 0 ? 'text-danger' : diff < 0 ? 'text-success' : 'text-gray-400'
+                        }`}>
+                          {diff > 0 ? <MdTrendingUp /> : diff < 0 ? <MdTrendingDown /> : null}
+                          {diff > 0 ? '+' : ''}{diff.toFixed(1)}%
+                        </span>
+                      ) : (
+                        <span className="text-gray-300">-</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        {filteredPrices.length === 0 && !loading && (
+          <p className="text-sm text-gray-400 text-center py-8">가격 데이터가 없습니다.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -244,3 +244,37 @@ export interface AppNotification {
   module: string;
   read: boolean;
 }
+
+// Market (KAMIS dailySalesList)
+export interface KamisItemPrice {
+  product_cls_code: string;  // 01:소매, 02:도매
+  product_cls_name: string;
+  category_code: string;
+  category_name: string;
+  productno: string;
+  lastest_day: string;
+  productName: string;
+  item_name: string;
+  unit: string;
+  day1: string;   // 당일 라벨
+  dpr1: string;   // 당일 가격
+  day2: string;   // 1일전 라벨
+  dpr2: string;   // 1일전 가격
+  day3: string;   // 1주일전 라벨
+  dpr3: string;   // 1주일전 가격
+  day4: string;   // 1개월전 라벨
+  dpr4: string;   // 1개월전 가격
+  direction: string;  // 1:상승, 2:하락, 0:변동없음
+  value: string;      // 등락율
+}
+
+export interface ImportantChange {
+  item_name: string;
+  productno: string;
+  category_name: string;
+  unit: string;
+  currentPrice: number;
+  previousPrice: number;
+  changePercent: number;
+  direction: 'up' | 'down';
+}


### PR DESCRIPTION
## 변경 요약
- Kamis API 를 사용한 실시간 시세 정보 페이지. (추후 다른 기능 자동화와 엮어서 사용 예정)


## 관련 이슈
- 없음

## 변경 내용
- 시세정보 페이지 추가

## 테스트
- [ㅇ ] 로컬 실행 (백엔드)
- [ㅇ] 로컬 실행 (프론트)
- [ㅇ] 주요 시나리오 확인:
  - 

********_중요_*******
백엔드 .env에
KAMIS_API_KEY=
KAMIS_CERT_ID=
넣어야합니다. 구글 드라이브 API 키 모음에 있습니다.