### PR TITLE
fix: KAMIS 요청에 User-Agent 헤더 추가

### DIFF
--- a/backend/app/services/kamis.py
+++ b/backend/app/services/kamis.py
@@ -33,7 +33,8 @@ class KamisService:
 
     async def _get(self, action: str, extra: dict[str, str] | None = None) -> dict:
         params = {"action": action, **self._common_params(), **(extra or {})}
-        async with httpx.AsyncClient(timeout=self.TIMEOUT) as client:
+        headers = {"User-Agent": "Mozilla/5.0"}
+        async with httpx.AsyncClient(timeout=self.TIMEOUT, headers=headers) as client:
             resp = await client.get(self.BASE_URL, params=params)
             resp.raise_for_status()
             return resp.json()


### PR DESCRIPTION
사소한 수정인데, claude가 원본 repo에 바로 PR을 올려버렸습니다. 죄송(...)


KAMIS에 API 요청을 했는데 막히길래 ```headers = {"User-Agent": "Mozilla/5.0"}``` 추가했습니다.

merge하면 이 fix/kamis-user-agent 브랜치는 지우겠습니다.