### PR TITLE
회원가입 카카오 우편번호 서비스 추가

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,5 +1,6 @@
 """SQLAlchemy async engine & session 관리."""
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
@@ -27,10 +28,25 @@ async def get_db():
         yield session
 
 
+async def _ensure_column_widths():
+    """기존 DB에서 컬럼 크기가 모델과 맞지 않을 때 자동 보정."""
+    async with engine.begin() as conn:
+        result = await conn.execute(text(
+            "SELECT character_maximum_length FROM information_schema.columns "
+            "WHERE table_name = 'users' AND column_name = 'location'"
+        ))
+        row = result.first()
+        if row and row[0] is not None and row[0] < 100:
+            await conn.execute(text(
+                "ALTER TABLE users ALTER COLUMN location TYPE VARCHAR(100)"
+            ))
+
+
 async def init_db():
     """앱 시작 시 테이블 생성."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    await _ensure_column_widths()
 
 
 async def close_db():

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -13,7 +13,7 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(10), nullable=False)
     password: Mapped[str] = mapped_column(String(255), nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
-    location: Mapped[str] = mapped_column(String(10), default="")
+    location: Mapped[str] = mapped_column(String(100), default="")
     area: Mapped[float] = mapped_column(Float, default=0.0)
     farmname: Mapped[str] = mapped_column(String(40), default="")
     profile: Mapped[str] = mapped_column(String(255), default="")

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -6,7 +6,7 @@ class SignupRequest(BaseModel):
     name: str = Field(min_length=2, max_length=10)
     email: str
     password: str = Field(min_length=4)
-    location: str = ""
+    location: str = Field(default="", max_length=100)
     area: float = 0.0
     farmname: str = ""
     profile: str = ""

--- a/frontend/src/modules/auth/SignupPage.tsx
+++ b/frontend/src/modules/auth/SignupPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
@@ -13,13 +13,38 @@ export default function SignupPage() {
     email: '',
     password: '',
     password_confirm: '',
-    location: '',
     area: '',
     farmname: '',
   });
   const [loading, setLoading] = useState(false);
+  const [postcode, setPostcode] = useState('');
+  const [roadAddress, setRoadAddress] = useState('');
+  const [detailAddress, setDetailAddress] = useState('');
+
+  useEffect(() => {
+    if (document.getElementById('daum-postcode-script')) return;
+    const script = document.createElement('script');
+    script.id = 'daum-postcode-script';
+    script.src = '//t1.kakaocdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.async = true;
+    document.head.appendChild(script);
+  }, []);
 
   const update = (field: string, value: string) => setForm(prev => ({ ...prev, [field]: value }));
+
+  const handleAddressSearch = () => {
+    if (typeof daum === 'undefined') {
+      toast.error('주소 검색 서비스를 불러올 수 없습니다.');
+      return;
+    }
+    new daum.Postcode({
+      oncomplete(data) {
+        setPostcode(data.zonecode);
+        setRoadAddress(data.roadAddress);
+        setDetailAddress('');
+      },
+    }).open();
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,7 +63,10 @@ export default function SignupPage() {
     setLoading(true);
     try {
       const { password_confirm, area, ...rest } = form;
-      const body = { ...rest, area: area ? parseFloat(area) : 0 };
+      const finalLocation = detailAddress
+        ? `${roadAddress} ${detailAddress}`.trim()
+        : roadAddress;
+      const body = { ...rest, location: finalLocation, area: area ? parseFloat(area) : 0 };
       const res = await fetch(`${API_BASE}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -101,8 +129,37 @@ export default function SignupPage() {
               <input type="text" value={form.farmname} onChange={e => update('farmname', e.target.value)} placeholder="선택 사항" className={inputClass} />
             </div>
             <div>
-              <label className="block text-base font-medium text-gray-700 mb-1">지역</label>
-              <input type="text" value={form.location} onChange={e => update('location', e.target.value)} placeholder="예: 경북 영주시" className={inputClass} />
+              <label className="block text-base font-medium text-gray-700 mb-1">주소</label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={postcode}
+                  readOnly
+                  placeholder="우편번호"
+                  className={`${inputClass} bg-gray-100 cursor-not-allowed flex-1`}
+                />
+                <button
+                  type="button"
+                  onClick={handleAddressSearch}
+                  className="px-4 py-3 bg-primary text-white rounded-xl font-semibold whitespace-nowrap hover:opacity-90 transition"
+                >
+                  우편번호 찾기
+                </button>
+              </div>
+              <input
+                type="text"
+                value={roadAddress}
+                readOnly
+                placeholder="도로명주소"
+                className={`${inputClass} bg-gray-100 cursor-not-allowed mt-2`}
+              />
+              <input
+                type="text"
+                value={detailAddress}
+                onChange={e => setDetailAddress(e.target.value)}
+                placeholder="상세주소 입력"
+                className={`${inputClass} mt-2`}
+              />
             </div>
             <div>
               <label className="block text-base font-medium text-gray-700 mb-1">면적 (평)</label>

--- a/frontend/src/types/kakao.d.ts
+++ b/frontend/src/types/kakao.d.ts
@@ -1,0 +1,19 @@
+interface DaumPostcodeData {
+  zonecode: string;
+  roadAddress: string;
+  jibunAddress: string;
+  autoRoadAddress: string;
+  autoJibunAddress: string;
+  buildingName: string;
+  apartment: 'Y' | 'N';
+  bname: string;
+  bname1: string;
+  userSelectedType: 'R' | 'J';
+}
+
+declare namespace daum {
+  class Postcode {
+    constructor(options: { oncomplete: (data: DaumPostcodeData) => void });
+    open(): void;
+  }
+}


### PR DESCRIPTION
## 변경 요약
- 회원가입 카카오 우편번호 서비스 추가

## 관련 이슈
- Closes #

## 변경 내용
- 회원가입 카카오 우편번호 서비스 추가

## 테스트
- [ㅇ ] 로컬 실행 (백엔드)
- [ㅇ ] 로컬 실행 (프론트)
- [ㅇ ] 주요 시나리오 확인:
  - 

## 스크린샷/녹화(선택)
- 
<img width="1056" height="593" alt="image" src="https://github.com/user-attachments/assets/8e9c3ddc-65d7-4bdd-bd7a-1224c599ce0b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added address lookup functionality to the signup form. Users can now search and select addresses using postcode lookup instead of manually entering location information.
  * Extended location field capacity to support longer addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->