### PR TITLE
JWT 세션 관리 문제 수정

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -7,7 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.deps import get_current_user
-from app.core.security import create_access_token, ACCESS_TOKEN_EXPIRE_MINUTES
+from app.core.security import (
+    create_access_token, create_refresh_token, decode_refresh_token,
+    ACCESS_TOKEN_EXPIRE_MINUTES, REFRESH_TOKEN_EXPIRE_DAYS,
+)
 from app.core import user_store
 from app.models.user import User
 from app.schemas.auth import (
@@ -18,6 +21,7 @@ from app.schemas.auth import (
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 COOKIE_KEY = "farmos_token"
+REFRESH_COOKIE_KEY = "farmos_refresh_token"
 
 # 비밀번호 재설정용 일회용 토큰 저장소 (인메모리, 5분 만료)
 _reset_tokens: dict[str, dict] = {}  # {token: {"user_id": str, "expires": float}}
@@ -57,6 +61,18 @@ def _set_token_cookie(response: Response, token: str):
     )
 
 
+def _set_refresh_cookie(response: Response, token: str):
+    response.set_cookie(
+        key=REFRESH_COOKIE_KEY,
+        value=token,
+        httponly=True,
+        secure=False,       # 개발환경 HTTP → False, 프로덕션에서는 True
+        samesite="lax",
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        path="/",
+    )
+
+
 def _user_response(user: User) -> UserResponse:
     """User 모델 → UserResponse 변환 헬퍼."""
     return UserResponse(
@@ -85,7 +101,9 @@ async def signup(req: SignupRequest, response: Response, db: AsyncSession = Depe
     if not user:
         raise HTTPException(400, "이미 사용 중인 아이디 또는 이메일입니다.")
     token = create_access_token({"sub": user.id, "name": user.name})
+    refresh_token = create_refresh_token({"sub": user.id, "name": user.name})
     _set_token_cookie(response, token)
+    _set_refresh_cookie(response, refresh_token)
     return _user_response(user)
 
 
@@ -102,7 +120,9 @@ async def login(req: LoginRequest, request: Request, response: Response, db: Asy
     # 로그인 성공 시 해당 IP의 시도 기록 초기화
     _login_attempts.pop(client_ip, None)
     token = create_access_token({"sub": user.id, "name": user.name})
+    refresh_token = create_refresh_token({"sub": user.id, "name": user.name})
     _set_token_cookie(response, token)
+    _set_refresh_cookie(response, refresh_token)
     return {"user_id": user.id, "name": user.name}
 
 
@@ -110,7 +130,27 @@ async def login(req: LoginRequest, request: Request, response: Response, db: Asy
 async def logout(response: Response):
     """로그아웃 — 쿠키 삭제."""
     response.delete_cookie(key=COOKIE_KEY, path="/")
+    response.delete_cookie(key=REFRESH_COOKIE_KEY, path="/")
     return {"message": "로그아웃되었습니다."}
+
+
+@router.post("/refresh")
+async def refresh_token(request: Request, response: Response, db: AsyncSession = Depends(get_db)):
+    """Refresh Token으로 새 Access Token 발급."""
+    refresh = request.cookies.get(REFRESH_COOKIE_KEY)
+    if not refresh:
+        raise HTTPException(401, "리프레시 토큰이 없습니다.")
+    payload = decode_refresh_token(refresh)
+    if payload is None:
+        response.delete_cookie(key=REFRESH_COOKIE_KEY, path="/")
+        raise HTTPException(401, "리프레시 토큰이 만료되었거나 유효하지 않습니다.")
+    user_id = payload.get("sub", "")
+    user = await user_store.find_by_id(db, user_id)
+    if user is None:
+        raise HTTPException(401, "사용자를 찾을 수 없습니다.")
+    new_access = create_access_token({"sub": user.id, "name": user.name})
+    _set_token_cookie(response, new_access)
+    return {"message": "토큰이 갱신되었습니다."}
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -9,15 +9,10 @@ import secrets
 
 from app.core.config import settings
 
-# settings.JWT_SECRET_KEY가 있으면 고정 키 사용,
-# 없으면 서버 시작마다 랜덤 생성 → 재시작 시 기존 세션 자동 무효화 (개발)
 SECRET_KEY = settings.JWT_SECRET_KEY or secrets.token_urlsafe(32)
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
-
-# 서버 시작마다 새로 생성 — 재시작 시 기존 토큰 무효화
-SERVER_BOOT_ID = secrets.token_urlsafe(8)
-print(f"[Security] SERVER_BOOT_ID = {SERVER_BOOT_ID}")
+REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 
 def hash_password(password: str) -> str:
@@ -31,17 +26,31 @@ def verify_password(plain: str, hashed: str) -> bool:
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "bid": SERVER_BOOT_ID})
+    to_encode.update({"exp": expire, "type": "access"})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(data: dict) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "type": "refresh"})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
 def decode_access_token(token: str) -> dict | None:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        token_bid = payload.get("bid")
-        print(f"[Security] token bid={token_bid}, server bid={SERVER_BOOT_ID}, match={token_bid == SERVER_BOOT_ID}")
-        # boot_id가 현재 서버와 다르면 재시작된 것 → 토큰 무효
-        if token_bid != SERVER_BOOT_ID:
+        if payload.get("type") != "access":
+            return None
+        return payload
+    except JWTError:
+        return None
+
+
+def decode_refresh_token(token: str) -> dict | None:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        if payload.get("type") != "refresh":
             return None
         return payload
     except JWTError:

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,9 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 
 const API_BASE = 'http://localhost:8000/api/v1';
+
+// Access token 만료 5분 전에 자동 갱신 (55분)
+const TOKEN_REFRESH_INTERVAL = 55 * 60 * 1000;
 
 export interface AuthUser {
   user_id: string;
@@ -35,14 +38,35 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // 앱 시작 시 쿠키 기반으로 서버에 인증 상태 확인
-  const checkAuth = useCallback(async () => {
+  const clearRefreshTimer = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearInterval(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+  }, []);
+
+  // Refresh Token으로 Access Token 갱신
+  const refreshAccessToken = useCallback(async (): Promise<boolean> => {
+    try {
+      const res = await fetch(`${API_BASE}/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  // 서버에서 현재 사용자 정보 조회
+  const fetchUser = useCallback(async (): Promise<AuthUser | null> => {
     try {
       const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
-        setUser({
+        return {
           user_id: data.user_id,
           name: data.name,
           email: data.email ?? '',
@@ -58,28 +82,50 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           has_farm_registration: data.has_farm_registration ?? false,
           years_rural_residence: data.years_rural_residence ?? 0,
           years_farming: data.years_farming ?? 0,
-        });
-      } else {
-        // 인증 실패 시 만료/무효 쿠키 정리
-        await fetch(`${API_BASE}/auth/logout`, { method: 'POST', credentials: 'include' }).catch(() => {});
+        };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // 토큰 자동 갱신 타이머 시작
+  const startRefreshTimer = useCallback(() => {
+    clearRefreshTimer();
+    refreshTimerRef.current = setInterval(async () => {
+      const refreshed = await refreshAccessToken();
+      if (!refreshed) {
+        clearRefreshTimer();
         setUser(null);
       }
-    } catch {
+    }, TOKEN_REFRESH_INTERVAL);
+  }, [refreshAccessToken, clearRefreshTimer]);
+
+  // 앱 시작 시 인증 상태 확인 (refresh 포함)
+  const checkAuth = useCallback(async () => {
+    let userData = await fetchUser();
+    if (!userData) {
+      // Access token 만료 → refresh 시도
+      const refreshed = await refreshAccessToken();
+      if (refreshed) {
+        userData = await fetchUser();
+      }
+    }
+    if (userData) {
+      setUser(userData);
+      startRefreshTimer();
+    } else {
       setUser(null);
+      clearRefreshTimer();
     }
     setIsLoading(false);
-  }, []);
+  }, [fetchUser, refreshAccessToken, startRefreshTimer, clearRefreshTimer]);
 
   useEffect(() => {
     checkAuth();
-  }, [checkAuth]);
-
-  // Periodic session re-validation — detects backend restart
-  useEffect(() => {
-    if (!user) return;
-    const interval = setInterval(checkAuth, 30_000);
-    return () => clearInterval(interval);
-  }, [user, checkAuth]);
+    return () => clearRefreshTimer();
+  }, [checkAuth, clearRefreshTimer]);
 
   const login = async (userId: string, password: string) => {
     const res = await fetch(`${API_BASE}/auth/login`, {
@@ -92,11 +138,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const err = await res.json();
       throw new Error(err.detail || '로그인에 실패했습니다.');
     }
-    // 로그인 후 전체 프로필 다시 조회 (onboarding_completed 포함)
     await checkAuth();
   };
 
   const logout = async () => {
+    clearRefreshTimer();
     await fetch(`${API_BASE}/auth/logout`, {
       method: 'POST',
       credentials: 'include',
@@ -105,8 +151,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const refreshUser = useCallback(async () => {
-    await checkAuth();
-  }, [checkAuth]);
+    const userData = await fetchUser();
+    if (userData) {
+      setUser(userData);
+    }
+  }, [fetchUser]);
 
   const needsOnboarding = !!user && !user.onboarding_completed;
 

--- a/shopping_mall/backend/app/farmos_auth.py
+++ b/shopping_mall/backend/app/farmos_auth.py
@@ -30,6 +30,9 @@ def get_farmos_user_optional(request: Request) -> FarmOSUser | None:
         return None
     try:
         payload = jwt.decode(token, FARMOS_SECRET_KEY, algorithms=[ALGORITHM])
+        # Refresh Token 거부 — Access Token만 허용
+        if payload.get("type") != "access":
+            return None
         user_id = payload.get("sub", "")
         name = payload.get("name", "")
         if not user_id:

--- a/shopping_mall/backend/app/routers/users.py
+++ b/shopping_mall/backend/app/routers/users.py
@@ -50,7 +50,7 @@ def auth_status(request: Request, db: Session = Depends(get_db)):
     if not token:
         return {"authenticated": False}
 
-    # FarmOS 백엔드에 직접 검증 요청 (boot_id 체크 포함)
+    # FarmOS 백엔드에 직접 검증 요청
     try:
         res = httpx.get(
             f"{FARMOS_API}/auth/me",


### PR DESCRIPTION
## 변경 요약
- JWT 세션 관리 로직 문제 수정. (이젠 리프래시 키와 시크릿 키가 공존합니다.)
- 기존에 JWT키에 SERVER_BOOT_ID를 더 붙혀줬었지만 이젠 아님.
- 쇼핑몰 인증 깨짐 수정.
- 폴링 타임 55분으로 수정.

## 관련 이슈
- Closes #

## 변경 내용
- JWT 로직 수정.

## 테스트
- [X] 로컬 실행 (백엔드)
- [X] 로컬 실행 (프론트)
- [X] 주요 시나리오 확인:
  - 테스트 후 PR

## 스크린샷/녹화(선택)
- 

## 체크리스트
- [X] 영향 범위(사용자/권한/성능/보안) 검토
- [ ] 실패 시 롤백/대안 고려(필요 시)
- [ ] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)
