### PR TITLE
refactor : 임베딩 설정 편의성 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build/
 # ========== ChromaDB ==========
 chroma_data/
 
+# ========== 정책 문서 (PDF/DOCX — 로컬 배치, 커밋 제외) ==========
+shopping_mall/backend/ai/docs/
+
 # ========== Environment variables ==========
 .env
 .env.local

--- a/shopping_mall/backend/.env.example
+++ b/shopping_mall/backend/.env.example
@@ -8,11 +8,30 @@ JWT_SECRET_KEY=your_jwt_secret_key_here
 # https://www.data.go.kr/data/15012690/openapi.do
 ANNIVERSARY_API_KEY=your_anniversary_api_key_here
 
-# Ollama (임베딩 전용)
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_EMBED_MODEL=embeddinggemma:latest
+# ── 임베딩 ────────────────────────────────────────────────────────────────
+# ⚠️  시딩(seed_rag.py)과 서버 실행 시 반드시 동일한 provider + model을 사용하세요.
+#     provider/model을 바꾸면 re-seed가 필요합니다.
+#
+# [옵션 1] OpenRouter — 추가 설정 없음, PRIMARY_LLM_API_KEY 자동 재사용 (권장)
+# EMBED_PROVIDER=openrouter
+# EMBED_MODEL=openai/text-embedding-3-small
+#
+# [옵션 2] Ollama — 로컬 Ollama 서버 필요
+# EMBED_PROVIDER=ollama
+# OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_EMBED_MODEL=embeddinggemma:latest
+#
+[옵션 3] sentence_transformers — API 키·서버 불필요, 로컬 실행 (Ollama·OpenRouter 없는 경우)
+  첫 실행 시 HuggingFace에서 모델 자동 다운로드. 설치: uv add sentence-transformers
+EMBED_PROVIDER=sentence_transformers
+EMBED_MODEL=jhgan/ko-sroberta-multitask
+#
+# [옵션 4] OpenAI Embeddings API
+# EMBED_PROVIDER=openai
+# EMBED_MODEL=text-embedding-3-small
+# EMBED_API_KEY=sk-...
 
-# Utility LLM - 리포트/비용분류 (Ollama 또는 OpenRouter)
+# Utility LLM — 프롬프트 1회 → 응답 구조 (tool_use 없음): 리포트 생성·비용 분류 전용
 # Ollama 사용 시:
 UTILITY_LLM_BASE_URL=http://localhost:11434/v1
 UTILITY_LLM_API_KEY=ollama
@@ -22,7 +41,7 @@ UTILITY_LLM_MODEL=qwen2.5:7b
 # UTILITY_LLM_API_KEY=sk-or-...
 # UTILITY_LLM_MODEL=google/gemma-3-27b-it
 
-# 에이전트 Primary LLM (Ollama 또는 OpenRouter)
+# Primary LLM — tool_use 에이전트 루프 전용: 챗봇이 도구를 선택·호출·해석하는 데 사용
 # Ollama 사용 시:
 # PRIMARY_LLM_BASE_URL=http://localhost:11434/v1
 # PRIMARY_LLM_API_KEY=ollama
@@ -38,3 +57,8 @@ CLAUDE_FALLBACK_MODEL=claude-haiku-4-5
 
 # 에이전트 최대 반복 횟수
 AGENT_MAX_ITERATIONS=10
+
+# 정책 문서 폴더 (PDF/DOCX — gitignore 처리, 직접 배치 필요)
+# 기본값: shopping_mall/backend/ai/docs/
+# 다른 경로를 쓰려면 아래 주석 해제 후 절대 경로 지정.
+# POLICY_DOCS_DIR=/path/to/your/docs

--- a/shopping_mall/backend/.env.example
+++ b/shopping_mall/backend/.env.example
@@ -21,8 +21,8 @@ ANNIVERSARY_API_KEY=your_anniversary_api_key_here
 # OLLAMA_BASE_URL=http://localhost:11434
 # OLLAMA_EMBED_MODEL=embeddinggemma:latest
 #
-[옵션 3] sentence_transformers — API 키·서버 불필요, 로컬 실행 (Ollama·OpenRouter 없는 경우)
-  첫 실행 시 HuggingFace에서 모델 자동 다운로드. 설치: uv add sentence-transformers
+# [옵션 3] sentence_transformers — API 키·서버 불필요, 로컬 실행 (Ollama·OpenRouter 없는 경우)
+#   첫 실행 시 HuggingFace에서 모델 자동 다운로드. 설치: uv add sentence-transformers
 EMBED_PROVIDER=sentence_transformers
 EMBED_MODEL=jhgan/ko-sroberta-multitask
 #

--- a/shopping_mall/backend/CLAUDE.md
+++ b/shopping_mall/backend/CLAUDE.md
@@ -19,7 +19,7 @@ PROJECT_ROOT    # FarmOS/
 LOG_DIR         # FarmOS/logs/
 CHROMA_DB_PATH  # .../backend/chroma_data/
 AI_DATA_DIR     # .../backend/ai/data/
-POLICY_DOCS_DIR # FarmOS/.claude/docs/
+POLICY_DOCS_DIR # .../backend/ai/docs/  (gitignore — 로컬에 PDF/DOCX 직접 배치)
 ```
 
 ---
@@ -88,6 +88,7 @@ await self._tool_get_order_status(db, user_id, **args)
 | `CLAUDE_FALLBACK_MODEL` | Claude Fallback 모델 (기본: `claude-haiku-4-5`) |
 | `AGENT_MAX_ITERATIONS` | 에이전트 최대 반복 횟수 (기본: `10`) |
 | `ANNIVERSARY_API_KEY` | 공공데이터포털 공휴일 API 키 |
+| `POLICY_DOCS_DIR` | 정책 문서 폴더 (기본: `ai/docs/`, gitignore — 로컬 배치 필요) |
 
 Provider 전환은 `PRIMARY_LLM_*` 세 값만 교체하면 됩니다. 자세한 예시는 `ai/agent/clients/README.md` 참고.
 

--- a/shopping_mall/backend/ai/README.md
+++ b/shopping_mall/backend/ai/README.md
@@ -1,14 +1,15 @@
 # ai/
 
-AI 기능 모음. 크게 **Ollama 기반 유틸리티**와 **에이전트 서브패키지**로 나뉩니다.
+AI 기능 모음. 크게 **유틸리티**와 **에이전트 서브패키지**로 나뉩니다.
 
 ## 파일
 
 | 파일 | 역할 |
 |------|------|
-| `llm_client.py` | Ollama LLM 클라이언트 — 리포트 생성(`generate_report`), 비용 분류(`classify_expense`) 전용. 챗봇 에이전트와는 무관 |
-| `rag.py` | ChromaDB 검색 서비스 — `retrieve()` / `retrieve_multiple()`로 관련 문서 반환. 답변 생성은 에이전트가 담당 |
-| `seed_rag.py` | ChromaDB 초기 데이터 적재 스크립트. JSON 및 PDF/DOCX를 파싱해 9개 컬렉션에 upsert |
+| `embeddings.py` | 임베딩 함수 팩토리 — `EMBED_PROVIDER` 설정에 따라 provider 선택 |
+| `llm_client.py` | Utility LLM 클라이언트 — 리포트 생성·비용 분류 전용. 챗봇 에이전트와 무관 |
+| `rag.py` | ChromaDB 검색 서비스 — `retrieve()` / `retrieve_multiple()`로 관련 문서 반환 |
+| `seed_rag.py` | ChromaDB 초기 데이터 적재 스크립트. JSON 및 PDF/DOCX를 파싱해 컬렉션에 upsert |
 
 ## 서브패키지
 
@@ -16,20 +17,65 @@ AI 기능 모음. 크게 **Ollama 기반 유틸리티**와 **에이전트 서브
 |----------|------|
 | `agent/` | tool_use 에이전트 전체 (executor, 도구, 클라이언트, 프롬프트) |
 | `data/` | RAG JSON 원본 데이터 (`faq.json`, `storage_guide.json`, `season_info.json`) |
+| `docs/` | 정책 문서 PDF/DOCX — gitignore 처리, 로컬에 직접 배치 필요 |
 
 ## ChromaDB 컬렉션
 
 ```
 faq / storage_guide / season_info          ← JSON (ai/data/)
 payment_policy / delivery_policy /
-return_policy / quality_policy /           ← PDF/DOCX (.claude/docs/)
+return_policy / quality_policy /           ← PDF/DOCX (ai/docs/)
 service_policy / membership_policy
 ```
 
-## 자주 쓰는 명령
+---
+
+## 팀원 셋업 가이드
+
+### 1단계 — 임베딩 provider 선택
+
+`.env`에서 본인 환경에 맞는 옵션을 선택합니다.
+**시딩과 서버 실행 시 반드시 동일한 provider + model을 사용해야 합니다.**
+
+**OpenRouter 키가 있는 경우 (권장)**
+```env
+EMBED_PROVIDER=openrouter
+EMBED_MODEL=openai/text-embedding-3-small
+# PRIMARY_LLM_API_KEY를 자동으로 재사용 — 추가 키 불필요
+```
+
+**Ollama가 설치된 경우**
+```env
+EMBED_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_EMBED_MODEL=embeddinggemma:latest
+```
+
+**둘 다 없는 경우 — 로컬 실행 (API 키·서버 불필요)**
+```env
+EMBED_PROVIDER=sentence_transformers
+EMBED_MODEL=jhgan/ko-sroberta-multitask
+```
+```bash
+uv add sentence-transformers   # 최초 1회
+```
+> 첫 실행 시 HuggingFace에서 모델을 자동 다운로드합니다 (~400MB).
+
+### 2단계 — 정책 문서 배치
+
+`ai/docs/` 폴더에 정책 문서(PDF/DOCX)를 넣습니다.
+폴더가 없으면 직접 생성하세요 (gitignore 처리되어 있습니다).
+
+```
+ai/docs/
+├── 01_주문및결제정책.pdf
+├── 02_배송정책.docx
+└── ...
+```
+
+### 3단계 — 시딩
 
 ```bash
-# RAG 시딩
 uv run python ai/seed_rag.py
 
 # 시딩 + 검색 검증 한번에

--- a/shopping_mall/backend/ai/embeddings.py
+++ b/shopping_mall/backend/ai/embeddings.py
@@ -5,7 +5,7 @@ EMBED_PROVIDER 설정에 따라 ChromaDB 임베딩 함수를 반환합니다.
 지원 provider:
   openrouter          — OpenRouter Embeddings API (PRIMARY_LLM_API_KEY 재사용, 추가 설정 불필요)
   ollama              — 로컬 Ollama 서버 (OLLAMA_BASE_URL + OLLAMA_EMBED_MODEL 사용)
-  sentence_transformers — HuggingFace 모델 로컬 실행 (API 키·서버 불필요, pip install만 필요)
+  sentence_transformers — HuggingFace 모델 로컬 실행 (API 키·서버 불필요, uv add sentence-transformers만 필요)
   openai              — OpenAI Embeddings API 또는 호환 엔드포인트 (EMBED_API_KEY 필요)
 
 ⚠️  시딩(seed_rag.py)과 쿼리(rag.py)는 반드시 동일한 provider + model을 사용해야 합니다.
@@ -31,6 +31,8 @@ def get_embedding_function():
         model = settings.embed_model or "openai/text-embedding-3-small"
         # PRIMARY_LLM_API_KEY를 기본으로 재사용 — 별도 키 불필요
         api_key = settings.embed_api_key or settings.primary_llm_api_key
+        if not api_key:
+            raise ValueError("openrouter requires a non-empty API key (EMBED_API_KEY 또는 PRIMARY_LLM_API_KEY)")
         return OpenAIEmbeddingFunction(
             api_key=api_key,
             model_name=model,
@@ -51,6 +53,8 @@ def get_embedding_function():
 
     elif provider == "openai":
         from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+        if not settings.embed_api_key:
+            raise ValueError("openai requires a non-empty API key (EMBED_API_KEY)")
         model = settings.embed_model or "text-embedding-3-small"
         kwargs: dict = {
             "api_key": settings.embed_api_key,

--- a/shopping_mall/backend/ai/embeddings.py
+++ b/shopping_mall/backend/ai/embeddings.py
@@ -1,0 +1,67 @@
+"""임베딩 함수 팩토리.
+
+EMBED_PROVIDER 설정에 따라 ChromaDB 임베딩 함수를 반환합니다.
+
+지원 provider:
+  openrouter          — OpenRouter Embeddings API (PRIMARY_LLM_API_KEY 재사용, 추가 설정 불필요)
+  ollama              — 로컬 Ollama 서버 (OLLAMA_BASE_URL + OLLAMA_EMBED_MODEL 사용)
+  sentence_transformers — HuggingFace 모델 로컬 실행 (API 키·서버 불필요, pip install만 필요)
+  openai              — OpenAI Embeddings API 또는 호환 엔드포인트 (EMBED_API_KEY 필요)
+
+⚠️  시딩(seed_rag.py)과 쿼리(rag.py)는 반드시 동일한 provider + model을 사용해야 합니다.
+    provider/model을 바꾸면 반드시 re-seed 하세요.
+"""
+from app.core.config import settings
+
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def get_embedding_function():
+    """설정(EMBED_PROVIDER)에 따라 ChromaDB 임베딩 함수를 반환.
+
+    Raises:
+        ValueError: 지원하지 않는 provider일 때
+        ImportError: 필요한 패키지가 설치되지 않았을 때
+        Exception: provider 초기화 실패 시
+    """
+    provider = settings.embed_provider.lower()
+
+    if provider == "openrouter":
+        from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+        model = settings.embed_model or "openai/text-embedding-3-small"
+        # PRIMARY_LLM_API_KEY를 기본으로 재사용 — 별도 키 불필요
+        api_key = settings.embed_api_key or settings.primary_llm_api_key
+        return OpenAIEmbeddingFunction(
+            api_key=api_key,
+            model_name=model,
+            api_base=_OPENROUTER_BASE_URL,
+        )
+
+    elif provider == "ollama":
+        from chromadb.utils.embedding_functions import OllamaEmbeddingFunction
+        return OllamaEmbeddingFunction(
+            url=f"{settings.ollama_base_url}/api/embeddings",
+            model_name=settings.ollama_embed_model,
+        )
+
+    elif provider == "sentence_transformers":
+        from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+        model = settings.embed_model or "jhgan/ko-sroberta-multitask"
+        return SentenceTransformerEmbeddingFunction(model_name=model)
+
+    elif provider == "openai":
+        from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+        model = settings.embed_model or "text-embedding-3-small"
+        kwargs: dict = {
+            "api_key": settings.embed_api_key,
+            "model_name": model,
+        }
+        if settings.embed_base_url:
+            kwargs["api_base"] = settings.embed_base_url
+        return OpenAIEmbeddingFunction(**kwargs)
+
+    else:
+        raise ValueError(
+            f"지원하지 않는 EMBED_PROVIDER: '{provider}'. "
+            "openrouter | ollama | sentence_transformers | openai 중 하나를 선택하세요."
+        )

--- a/shopping_mall/backend/ai/rag.py
+++ b/shopping_mall/backend/ai/rag.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from app.core.config import settings
 from app.paths import CHROMA_DB_PATH
+from ai.embeddings import get_embedding_function
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +23,9 @@ class RAGService:
         """Initialize ChromaDB client. Gracefully handles unavailability."""
         try:
             import chromadb
-            from chromadb.utils.embedding_functions import OllamaEmbeddingFunction
             self.chroma_client = chromadb.PersistentClient(path=persist_directory)
-            self._ef = OllamaEmbeddingFunction(
-                url=f"{settings.ollama_base_url}/api/embeddings",
-                model_name=settings.ollama_embed_model,
-            )
-            logger.info("ChromaDB initialized successfully.")
+            self._ef = get_embedding_function()
+            logger.info("ChromaDB initialized (provider=%s).", settings.embed_provider)
         except Exception as e:
             logger.warning(f"ChromaDB initialization failed: {e}. RAG will use fallback.")
             self.chroma_client = None

--- a/shopping_mall/backend/ai/seed_rag.py
+++ b/shopping_mall/backend/ai/seed_rag.py
@@ -13,13 +13,13 @@ import sys
 # shopping_mall/backend를 sys.path에 추가 (python ai/seed_rag.py 직접 실행 시 필요)
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.paths import CHROMA_DB_PATH, AI_DATA_DIR, POLICY_DOCS_DIR
+from app.core.config import settings
+from app.paths import CHROMA_DB_PATH, AI_DATA_DIR
+from ai.embeddings import get_embedding_function
 
 DATA_DIR = str(AI_DATA_DIR)
 CHROMA_DIR = CHROMA_DB_PATH
-
-# 정책 문서 경로: 환경변수 POLICY_DOCS_DIR로 오버라이드 가능
-DOCS_DIR = os.environ.get("POLICY_DOCS_DIR", str(POLICY_DOCS_DIR))
+DOCS_DIR = settings.policy_docs_dir
 
 # 파일명(부분 일치) → ChromaDB 컬렉션명 매핑
 DOC_TO_COLLECTION: dict[str, str] = {
@@ -226,21 +226,6 @@ def seed_season_info(client, ef) -> int:
 
 # ── 진입점 ─────────────────────────────────────────────────────────────────
 
-def get_embedding_function():
-    try:
-        from chromadb.utils.embedding_functions import OllamaEmbeddingFunction
-        from app.core.config import settings
-        return OllamaEmbeddingFunction(
-            url=f"{settings.ollama_base_url}/api/embeddings",
-            model_name=settings.ollama_embed_model,
-        )
-    except Exception as e:
-        print(f"[경고] Ollama 임베딩 함수 초기화 실패: {e}")
-        from app.core.config import settings
-        print(f"  → Ollama 서버가 실행 중인지 확인하세요: {settings.ollama_base_url}")
-        sys.exit(1)
-
-
 def find_policy_files() -> list[tuple[str, str]]:
     """DOCS_DIR에서 DOC_TO_COLLECTION 매핑에 해당하는 파일을 찾아 반환.
 
@@ -286,7 +271,13 @@ def main():
 
     print(f"ChromaDB 초기화 중... ({CHROMA_DIR})")
     client = chromadb.PersistentClient(path=CHROMA_DIR)
-    ef = get_embedding_function()
+    try:
+        ef = get_embedding_function()
+        print(f"임베딩 provider: {settings.embed_provider}")
+    except Exception as e:
+        print(f"[오류] 임베딩 함수 초기화 실패: {e}")
+        print(f"  → EMBED_PROVIDER={settings.embed_provider} 설정을 확인하세요.")
+        sys.exit(1)
 
     # ── JSON 기반 컬렉션 ──
     print("\n[JSON 컬렉션 적재]")

--- a/shopping_mall/backend/app/core/config.py
+++ b/shopping_mall/backend/app/core/config.py
@@ -1,6 +1,8 @@
 """애플리케이션 설정 — 환경변수를 한 곳에서 관리합니다."""
 from pydantic_settings import BaseSettings
 
+from app.paths import POLICY_DOCS_DIR
+
 
 class Settings(BaseSettings):
     # ── 데이터베이스 ────────────────────────────────────────────────────────
@@ -9,7 +11,19 @@ class Settings(BaseSettings):
     # ── 인증 ────────────────────────────────────────────────────────────────
     jwt_secret_key: str = ""
 
-    # ── Ollama (임베딩 전용) ─────────────────────────────────────────────────
+    # ── 임베딩 ──────────────────────────────────────────────────────────────
+    # provider: openrouter | ollama | sentence_transformers | openai
+    # ⚠️  시딩과 쿼리는 동일한 provider + model이어야 합니다. 변경 시 re-seed 필요.
+    embed_provider: str = "ollama"
+    # openrouter 기본값: openai/text-embedding-3-small (PRIMARY_LLM_API_KEY 재사용)
+    # sentence_transformers 기본값: jhgan/ko-sroberta-multitask (한국어 특화)
+    # openai 기본값: text-embedding-3-small
+    # 비워두면 provider별 기본값 사용
+    embed_model: str = ""
+    embed_api_key: str = ""      # openai provider 전용 (openrouter는 primary_llm_api_key 재사용)
+    embed_base_url: str = ""     # openai-compatible 엔드포인트 오버라이드 (선택)
+
+    # ── Ollama (embed_provider=ollama 일 때 사용) ────────────────────────────
     ollama_base_url: str = "http://localhost:11434"
     ollama_embed_model: str = "embeddinggemma:latest"
 
@@ -32,6 +46,11 @@ class Settings(BaseSettings):
 
     # ── 외부 API ────────────────────────────────────────────────────────────
     anniversary_api_key: str = ""
+
+    # ── 경로 ────────────────────────────────────────────────────────────────
+    # 정책 문서(PDF/DOCX) 폴더. 기본값: shopping_mall/backend/ai/docs/
+    # 다른 위치를 쓰려면 .env에 POLICY_DOCS_DIR=/절대/경로 로 지정.
+    policy_docs_dir: str = str(POLICY_DOCS_DIR)
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/shopping_mall/backend/app/paths.py
+++ b/shopping_mall/backend/app/paths.py
@@ -26,5 +26,5 @@ CHROMA_DB_PATH = str(BACKEND_ROOT / "chroma_data")
 # shopping_mall/backend/ai/data/
 AI_DATA_DIR = AI_DIR / "data"
 
-# FarmOS/.claude/docs/  (정책 문서)
-POLICY_DOCS_DIR = PROJECT_ROOT / ".claude" / "docs"
+# shopping_mall/backend/ai/docs/  (정책 문서 — gitignore 처리, 로컬에 PDF/DOCX 배치)
+POLICY_DOCS_DIR = AI_DIR / "docs"

--- a/shopping_mall/backend/scripts/README.md
+++ b/shopping_mall/backend/scripts/README.md
@@ -11,7 +11,7 @@
 ## 실행
 
 ```bash
-# RAG 시딩 + 검증 (Ollama 실행 중이어야 함)
+# RAG 시딩 + 검증 (.env의 EMBED_PROVIDER 설정 사용)
 uv run python scripts/seed_and_verify.py
 ```
 


### PR DESCRIPTION
## 변경 요약
- 임베딩 provider를 Ollama 단독에서 OpenRouter / sentence_transformers / OpenAI 중 선택 가능하도록 변경
- 환경 설정 관리 지점을 config.py + .env로 단일화
- 정책 문서 경로를 .claude/docs/ → ai/docs/로 이동 및 gitignore 처리


## 관련 이슈
- Closes #

## 변경 내용
- ai/embeddings.py 신규: provider별 임베딩 함수 팩토리 (openrouter / ollama /
  sentence_transformers / openai)
  - app/core/config.py: embed_provider, embed_model, embed_api_key, policy_docs_dir 필드 추가    
  - app/paths.py: POLICY_DOCS_DIR 경로 변경 (.claude/docs/ → ai/docs/)
  - ai/rag.py, ai/seed_rag.py: 하드코딩된 Ollama 의존 제거, embeddings.py 팩토리로 통일
  - .env.example: provider별 설정 예시 및 주석 추가
  - ai/README.md: 팀원 셋업 가이드 추가 (provider 선택 → 문서 배치 → 시딩)
  - .gitignore: ai/docs/ 추가

## 테스트
- [ ] 로컬 실행 (백엔드)
- [ ] 로컬 실행 (프론트)
- [ ] 주요 시나리오 확인:
  - EMBED_PROVIDER=openrouter 설정 후 seed_rag.py 정상 실행
  - EMBED_PROVIDER=ollama 설정 후 seed_rag.py 정상 실행
  - 챗봇 RAG 검색 정상 동작


## 스크린샷/녹화(선택)
- 

## 체크리스트
- [ ] 영향 범위(사용자/권한/성능/보안) 검토
- [ ] 실패 시 롤백/대안 고려(필요 시)
- [ ] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 여러 임베딩 프로바이더 지원 추가 (OpenRouter, Ollama, sentence-transformers, OpenAI)

* **Documentation**
  * 임베딩 프로바이더 선택 및 정책 문서 배치 절차가 포함된 팀원 셋업 가이드 추가
  * 정책 문서 디렉토리 경로 변경 및 명확화

* **Chores**
  * 정책 문서 디렉토리를 버전 관리에서 제외하도록 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->