### PR TITLE
fix: 부트스트랩 스크립트 수정

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -8,12 +8,17 @@
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import os
+import queue
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import IO
 
@@ -30,6 +35,34 @@ PORTS = [8000, 4000, 5173, 5174]
 
 class BootstrapError(RuntimeError):
     """부트스트랩 실패를 표현하는 예외."""
+
+
+@dataclass
+class BootstrapOptions:
+    """부트스트랩 실행 옵션."""
+
+    verbose_table_info: bool = False
+
+
+@dataclass
+class ServiceProcess:
+    """실행 중인 하위 서비스를 추적하기 위한 정보."""
+
+    name: str
+    process: subprocess.Popen[bytes]
+    log_handle: IO[str]
+    log_path: Path
+    exit_reported: bool = False
+    exit_code: int | None = None
+
+
+@dataclass
+class InputReaderController:
+    """입력 스레드 제어 정보를 묶는다."""
+
+    thread: threading.Thread
+    prompt_request: threading.Event
+    stop_reader: threading.Event
 
 
 def info(message: str) -> None:
@@ -59,11 +92,7 @@ def run_command(
                 stderr=subprocess.STDOUT,
             )
     else:
-        result = subprocess.run(
-            resolved,
-            cwd=str(cwd) if cwd else None,
-            text=True,
-        )
+        result = subprocess.run(resolved, cwd=str(cwd) if cwd else None, text=True)
     if check and result.returncode != 0:
         raise BootstrapError(
             f"명령 실행 실패({result.returncode}): {' '.join(command)}"
@@ -86,40 +115,101 @@ def ensure_uv_project(project_dir: Path, label: str, log_name: str) -> None:
     run_command(["uv", "sync"], cwd=project_dir, log_file=LOG_DIR / log_name)
 
 
+def compute_file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def compute_npm_state_hash(project_dir: Path) -> str:
+    package_json = project_dir / "package.json"
+    package_lock = project_dir / "package-lock.json"
+    digest_source = [f"package.json:{compute_file_sha256(package_json)}"]
+    if package_lock.exists():
+        digest_source.append(f"package-lock.json:{compute_file_sha256(package_lock)}")
+    else:
+        digest_source.append("package-lock.json:missing")
+    return hashlib.sha256("|".join(digest_source).encode("utf-8")).hexdigest()
+
+
+def npm_state_stamp_path(project_dir: Path) -> Path:
+    return project_dir / "node_modules" / ".bootstrap-npm-state"
+
+
+def read_npm_state_stamp(project_dir: Path) -> str | None:
+    stamp_path = npm_state_stamp_path(project_dir)
+    if not stamp_path.exists():
+        return None
+    return stamp_path.read_text(encoding="utf-8").strip() or None
+
+
+def write_npm_state_stamp(project_dir: Path, state_hash: str) -> None:
+    stamp_path = npm_state_stamp_path(project_dir)
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.write_text(state_hash + "\n", encoding="utf-8")
+
+
 def ensure_npm_project(project_dir: Path, label: str, log_name: str) -> None:
-    if not (project_dir / "package.json").exists():
+    package_json = project_dir / "package.json"
+    if not package_json.exists():
         raise BootstrapError(f"{label}: package.json 누락 ({project_dir})")
-    if (project_dir / "node_modules").exists():
-        info(f"{label}: node_modules 존재 (npm install 생략)")
+
+    should_install = True
+    desired_state_hash = compute_npm_state_hash(project_dir)
+    node_modules_dir = project_dir / "node_modules"
+    if node_modules_dir.exists():
+        saved_state_hash = read_npm_state_stamp(project_dir)
+        if saved_state_hash == desired_state_hash:
+            info(f"{label}: node_modules 상태 일치 (npm install 생략)")
+            should_install = False
+        else:
+            info(f"{label}: 의존성 상태 변경 감지 (npm install 실행)")
+
+    if not should_install:
         return
+
     info(f"{label}: npm install 실행")
     run_command(["npm", "install"], cwd=project_dir, log_file=LOG_DIR / log_name)
+    write_npm_state_stamp(project_dir, compute_npm_state_hash(project_dir))
 
 
-def ensure_databases() -> None:
+def parse_args() -> BootstrapOptions:
+    parser = argparse.ArgumentParser(description="FarmOS 통합 부트스트랩")
+    parser.add_argument(
+        "--verbose-table-info",
+        action="store_true",
+        help="DB 초기화 요약에 테이블 상세(컬럼/row 수)를 출력",
+    )
+    args = parser.parse_args()
+    return BootstrapOptions(verbose_table_info=args.verbose_table_info)
+
+
+def ensure_databases(options: BootstrapOptions) -> None:
     """DB/테이블 점검 및 필요 시 초기화를 `bootstrap/` 하위에 위임한다."""
     info("ShoppingMall DB 점검/초기화")
-    run_command(
-        [
-            "python",
-            str(Path("bootstrap") / "shoppingmall.py"),
-            "--mode",
-            "ensure",
-            "--skip-sync",
-        ],
-        cwd=ROOT,
-    )
+    shop_command = [
+        "python",
+        str(Path("bootstrap") / "shoppingmall.py"),
+        "--mode",
+        "ensure",
+        "--skip-sync",
+    ]
+    if options.verbose_table_info:
+        shop_command.append("--verbose-table-info")
+    run_command(shop_command, cwd=ROOT)
     info("FarmOS DB 점검/초기화")
-    run_command(
-        [
-            "python",
-            str(Path("bootstrap") / "farmos.py"),
-            "--mode",
-            "ensure",
-            "--skip-sync",
-        ],
-        cwd=ROOT,
-    )
+    farmos_command = [
+        "python",
+        str(Path("bootstrap") / "farmos.py"),
+        "--mode",
+        "ensure",
+        "--skip-sync",
+    ]
+    if options.verbose_table_info:
+        farmos_command.append("--verbose-table-info")
+    run_command(farmos_command, cwd=ROOT)
 
 
 def start_service(
@@ -127,18 +217,26 @@ def start_service(
     command: Iterable[str],
     cwd: Path,
     log_name: str,
-) -> tuple[str, subprocess.Popen[bytes], IO[str]]:
+) -> ServiceProcess:
     log_path = LOG_DIR / log_name
     log_handle = log_path.open("w", encoding="utf-8")
+    creationflags = 0
+    if os.name == "nt":
+        # 자식 프로세스의 콘솔 제어 이벤트가 부모 부트스트랩까지 전파되지 않도록 분리한다.
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
     proc = subprocess.Popen(
         resolve_command(list(command)),
         cwd=str(cwd),
         stdout=log_handle,
         stderr=subprocess.STDOUT,
         stdin=subprocess.DEVNULL,
+        creationflags=creationflags,
     )
     info(f"시작됨: {name} (PID={proc.pid})")
-    return name, proc, log_handle
+    return ServiceProcess(
+        name=name, process=proc, log_handle=log_handle, log_path=log_path
+    )
 
 
 def stop_process_tree(pid: int) -> None:
@@ -165,30 +263,95 @@ def pids_from_port(port: int) -> list[int]:
         if marker not in line or "LISTENING" not in line:
             continue
         parts = line.split()
-        if len(parts) >= 5 and parts[1].rsplit(":", 1)[-1] == str(port) and parts[-1].isdigit():
+        if (
+            len(parts) >= 5
+            and parts[1].rsplit(":", 1)[-1] == str(port)
+            and parts[-1].isdigit()
+        ):
             pids.add(int(parts[-1]))
     return sorted(pids)
 
 
-def stop_services(services: list[tuple[str, subprocess.Popen[bytes], IO[str]]]) -> None:
+def read_log_tail(path: Path, line_count: int = 30) -> list[str]:
+    if line_count <= 0 or not path.exists():
+        return []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        lines = handle.read().splitlines()
+    return lines[-line_count:]
+
+
+def report_service_failures(services: list[ServiceProcess]) -> tuple[bool, bool]:
+    has_failure = False
+    any_running = False
+    for service in services:
+        return_code = service.process.poll()
+        if return_code is None:
+            any_running = True
+            continue
+        if service.exit_reported:
+            continue
+        service.exit_code = return_code
+        service.exit_reported = True
+        if return_code == 0:
+            info(f"종료됨: {service.name} (PID={service.process.pid}, code=0)")
+            continue
+        has_failure = True
+        info(
+            f"오류: {service.name} 비정상 종료 (PID={service.process.pid}, code={return_code})"
+        )
+        tail_lines = read_log_tail(service.log_path, line_count=30)
+        if tail_lines:
+            print(f"[Bootstrap] {service.name} 최근 로그 (마지막 30줄):")
+            for line in tail_lines:
+                print(f"[Bootstrap]   {line}")
+        else:
+            print(
+                f"[Bootstrap] {service.name} 로그가 비어 있거나 읽을 수 없습니다: {service.log_path}"
+            )
+    all_stopped = bool(services) and not any_running
+    return has_failure, all_stopped
+
+
+def start_input_reader(command_queue: queue.Queue[str | None]) -> InputReaderController:
+    prompt_request = threading.Event()
+    stop_reader = threading.Event()
+
+    def reader() -> None:
+        while not stop_reader.is_set():
+            if not prompt_request.wait(timeout=0.2):
+                continue
+            prompt_request.clear()
+            if stop_reader.is_set():
+                break
+            try:
+                user_input = input("> ")
+            except EOFError:
+                command_queue.put(None)
+                continue
+            if stop_reader.is_set():
+                break
+            command_queue.put(user_input)
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    return InputReaderController(
+        thread=thread, prompt_request=prompt_request, stop_reader=stop_reader
+    )
+
+
+def stop_services(services: list[ServiceProcess]) -> None:
     info("서비스 종료 중...")
-    for name, proc, log_handle in services:
-        if proc.poll() is None:
-            info(f"종료: {name} (PID={proc.pid})")
-            stop_process_tree(proc.pid)
-        log_handle.close()
+    for service in services:
+        if service.process.poll() is None:
+            info(f"종료: {service.name} (PID={service.process.pid})")
+            stop_process_tree(service.process.pid)
+        service.log_handle.close()
     for port in PORTS:
         for pid in pids_from_port(port):
             stop_process_tree(pid)
-    # subprocess.run(
-    #     ["taskkill", "/F", "/IM", "node.exe"],
-    #     stdout=subprocess.DEVNULL,
-    #     stderr=subprocess.DEVNULL,
-    #     check=False,
-    # )
 
 
-def run() -> None:
+def run(options: BootstrapOptions) -> None:
     os.chdir(ROOT)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -199,14 +362,14 @@ def run() -> None:
     info("Shop Frontend    : http://localhost:5174")
 
     check_required_tools()
-    ensure_databases()
+    ensure_databases(options)
 
     ensure_uv_project(FARMOS_BACKEND_DIR, "FarmOS Backend", "farmos-be-setup.log")
     ensure_uv_project(SHOP_BACKEND_DIR, "Shop Backend", "shop-be-setup.log")
     ensure_npm_project(FARMOS_FRONTEND_DIR, "FarmOS Frontend", "farmos-fe-install.log")
     ensure_npm_project(SHOP_FRONTEND_DIR, "Shop Frontend", "shop-fe-install.log")
 
-    services: list[tuple[str, subprocess.Popen[bytes], IO[str]]] = []
+    services: list[ServiceProcess] = []
     try:
         services.append(
             start_service(
@@ -239,17 +402,39 @@ def run() -> None:
             )
         )
         print("\n모든 서비스가 실행되었습니다. 종료하려면 x/q/exit 입력 후 Enter.")
+        command_queue: queue.Queue[str | None] = queue.Queue()
+        input_controller = start_input_reader(command_queue)
+        input_controller.prompt_request.set()
+        input_closed = False
         while True:
-            try:
-                user_input = input("> ")
-            except EOFError:
-                info("표준 입력이 닫혀 서비스를 종료합니다.")
+            has_failure, all_stopped = report_service_failures(services)
+            if has_failure:
+                info("하위 서비스 오류로 인해 종료 절차를 시작합니다.")
+                input_controller.stop_reader.set()
                 break
+            if all_stopped:
+                info("모든 하위 서비스가 종료되어 종료 절차를 시작합니다.")
+                input_controller.stop_reader.set()
+                break
+            try:
+                user_input = command_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if user_input is None:
+                if not input_closed:
+                    info("표준 입력을 읽을 수 없어 입력 종료 기능을 비활성화합니다.")
+                    info("종료하려면 Ctrl+C 를 누르세요.")
+                    input_closed = True
+                input_controller.stop_reader.set()
+                continue
             command = user_input.strip().lower()
             if command in {"x", "q", "exit", "quit"}:
+                input_controller.stop_reader.set()
                 break
             if command == "":
                 print("종료하려면 x/q/exit 를 입력하세요.")
+            if not input_closed:
+                input_controller.prompt_request.set()
     finally:
         stop_services(services)
         print("모든 서비스를 종료했습니다.")
@@ -257,7 +442,7 @@ def run() -> None:
 
 if __name__ == "__main__":
     try:
-        run()
+        run(parse_args())
     except KeyboardInterrupt:
         print("\n사용자 인터럽트로 종료합니다.")
         raise SystemExit(130) from None

--- a/bootstrap/_bootstrap_common.py
+++ b/bootstrap/_bootstrap_common.py
@@ -254,9 +254,19 @@ def describe_table_columns(
     return columns
 
 
-def print_table_summary(db_conf: dict[str, str], label: str, tables: list[str]) -> None:
+def print_table_summary(
+    db_conf: dict[str, str],
+    label: str,
+    tables: list[str],
+    verbose_table_info: bool = False,
+) -> None:
     print()
     info(f"{label} 테이블 요약")
+    if not verbose_table_info:
+        for table in tables:
+            print(f"  - {table}")
+        return
+
     for table in tables:
         if not table_exists(db_conf, table):
             print(f"  - {table}: MISSING")

--- a/bootstrap/farmos.py
+++ b/bootstrap/farmos.py
@@ -83,8 +83,6 @@ def run_pesticide_loader(raw_db_url: str) -> None:
     loader_script = ROOT / "bootstrap" / "pesticide.py"
     json_dir = ROOT / "tools" / "api-crawler" / "json_raw"
     command = [
-        "--db-type",
-        "postgresql",
         "--db-url",
         raw_db_url,
         "--input-dir",
@@ -118,8 +116,13 @@ def is_farmos_ready(db_conf: dict[str, str]) -> bool:
     return True
 
 
-def print_summary(db_conf: dict[str, str]) -> None:
-    print_table_summary(db_conf, "FarmOS", FARMOS_TABLES)
+def print_summary(db_conf: dict[str, str], verbose_table_info: bool) -> None:
+    print_table_summary(
+        db_conf,
+        "FarmOS",
+        FARMOS_TABLES,
+        verbose_table_info=verbose_table_info,
+    )
 
 
 def initialize(db_conf: dict[str, str], raw_db_url: str, skip_sync: bool) -> None:
@@ -138,6 +141,11 @@ def main() -> int:
         choices=("init", "ensure"),
         default="init",
         help="init=항상 재초기화, ensure=필요할 때만 초기화",
+    )
+    parser.add_argument(
+        "--verbose-table-info",
+        action="store_true",
+        help="테이블 컬럼/row 수 상세 정보를 출력",
     )
     args = parser.parse_args()
 
@@ -161,7 +169,7 @@ def main() -> int:
         else:
             initialize(db_conf, raw_db_url, args.skip_sync)
         if initialized:
-            print_summary(db_conf)
+            print_summary(db_conf, args.verbose_table_info)
             print()
             info("FarmOS 데이터베이스 초기화 완료")
         else:

--- a/bootstrap/pesticide.py
+++ b/bootstrap/pesticide.py
@@ -36,7 +36,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, rela
 SERVICE_ID = "I1910"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_DIR = PROJECT_ROOT / "tools" / "api-crawler" / "json_raw"
-DEFAULT_SQLITE_PATH = Path("sqlite3/rag.sqlite3")
 DEFAULT_BACKEND_ENV_PATH = PROJECT_ROOT / "backend" / ".env"
 DEFAULT_ENV_EXAMPLE_PATH = PROJECT_ROOT / "tools" / "api-crawler" / ".env.example"
 DEFAULT_ENV_VALUES = (
@@ -78,18 +77,6 @@ PARSER.add_argument(
     type=Path,
     default=DEFAULT_BACKEND_ENV_PATH,
     help="PostgreSQL 접속 정보 로딩에 사용할 backend/.env 경로",
-)
-PARSER.add_argument(
-    "--db-type",
-    choices=("sqlite", "postgresql"),
-    default="sqlite",
-    help="적재 대상 DB 종류",
-)
-PARSER.add_argument(
-    "--sqlite-path",
-    type=Path,
-    default=DEFAULT_SQLITE_PATH,
-    help="SQLite DB 파일 경로",
 )
 PARSER.add_argument("--postgres-host", default=None, help="PostgreSQL 호스트")
 PARSER.add_argument("--postgres-port", type=int, default=None, help="PostgreSQL 포트")
@@ -870,10 +857,6 @@ def upsert_rag_document(
     return existing
 
 
-def ensure_parent_dir(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
 def load_backend_env(env_path: Path) -> None:
     if env_path.exists():
         load_dotenv(dotenv_path=env_path, override=False)
@@ -916,9 +899,6 @@ def build_engine(args: argparse.Namespace):
                 connect_args={"connect_timeout": int(POSTGRES_PING_TIMEOUT_SECONDS)},
             )
         return create_engine(db_url, future=True)
-    if args.db_type == "sqlite":
-        ensure_parent_dir(args.sqlite_path)
-        return create_engine(f"sqlite:///{args.sqlite_path.as_posix()}", future=True)
     env_db_url = normalize_db_url(os.getenv("DATABASE_URL"))
     if env_db_url:
         if env_db_url.startswith("postgresql+psycopg2://"):
@@ -961,9 +941,6 @@ def build_engine(args: argparse.Namespace):
 
 
 def wait_for_postgres_server(engine: Any, max_retries: int) -> None:
-    if engine.url.get_backend_name() != "postgresql":
-        return
-
     host = engine.url.host or DEFAULT_POSTGRES_HOST
     port = int(engine.url.port or DEFAULT_POSTGRES_PORT)
     log(f"PostgreSQL 서버 연결 확인 시작: {host}:{port}")
@@ -1181,17 +1158,15 @@ def main() -> int:
         raise RuntimeError("--postgres-max-retries 는 1 이상이어야 합니다.")
     input_dir: Path = args.input_dir
     if not input_dir.exists() or not input_dir.is_dir():
-        raise RuntimeError(f"입력 디렉터리가 없습니다: {input_dir}")
+        error(f"json_raw 디렉터리가 없어 적재를 건너뜁니다: {input_dir}")
+        return 0
 
     source_files = collect_source_files(input_dir, args.glob)
     if not source_files:
-        raise RuntimeError(
-            f"{input_dir} 아래에서 {args.glob!r} 패턴에 맞는 파일을 찾지 못했습니다."
-        )
+        error(f"json_raw 파일이 없어 적재를 건너뜁니다: {input_dir}")
+        return 0
 
-    log(
-        f"전처리 시작: input_dir={input_dir.as_posix()}, files={len(source_files)}, db_type={args.db_type}"
-    )
+    log(f"전처리 시작: input_dir={input_dir.as_posix()}, files={len(source_files)}")
     engine = build_engine(args)
     wait_for_postgres_server(engine, max_retries=args.postgres_max_retries)
     if not args.append:
@@ -1208,9 +1183,7 @@ def main() -> int:
         log("DB commit을 수행합니다.")
         session.commit()
 
-    if args.db_type == "sqlite" and not args.db_url:
-        destination = args.sqlite_path
-    elif args.db_type == "postgresql" and not args.db_url:
+    if not args.db_url:
         destination = normalize_db_url(os.getenv("DATABASE_URL")) or (
             f"{first_non_empty(args.postgres_host, os.getenv('POSTGRES_HOST'), DEFAULT_POSTGRES_HOST)}:"
             f"{int(first_non_empty(args.postgres_port, os.getenv('POSTGRES_PORT'), DEFAULT_POSTGRES_PORT))}/"

--- a/bootstrap/shoppingmall.py
+++ b/bootstrap/shoppingmall.py
@@ -99,8 +99,13 @@ def _to_sync_db_url(raw_db_url: str) -> str:
     return url
 
 
-def print_summary(db_conf: dict[str, str]) -> None:
-    print_table_summary(db_conf, "ShoppingMall", SHOP_TABLES)
+def print_summary(db_conf: dict[str, str], verbose_table_info: bool) -> None:
+    print_table_summary(
+        db_conf,
+        "ShoppingMall",
+        SHOP_TABLES,
+        verbose_table_info=verbose_table_info,
+    )
 
 
 def is_shoppingmall_ready(db_conf: dict[str, str]) -> bool:
@@ -150,6 +155,11 @@ def main() -> int:
         default="init",
         help="init=항상 재초기화, ensure=필요할 때만 초기화",
     )
+    parser.add_argument(
+        "--verbose-table-info",
+        action="store_true",
+        help="테이블 컬럼/row 수 상세 정보를 출력",
+    )
     args = parser.parse_args()
 
     try:
@@ -171,7 +181,7 @@ def main() -> int:
         else:
             initialize(db_conf, raw_db_url, args.skip_sync)
         if initialized:
-            print_summary(db_conf)
+            print_summary(db_conf, args.verbose_table_info)
             print()
             info("ShoppingMall 데이터베이스 초기화 완료")
         else:


### PR DESCRIPTION
부트스트랩 스크립트에 문제가 있어 긴급하게 PR을 올립니다.

- `api-crawler` 관련 파일이 없으면 오류 메시지 하나만 올리고 계속 진행
- 백엔드 `uvicorn reload`가 부트스트랩까지 같이 죽이는 문제 수정
- 프론트엔드 `npm install`을 단순 디렉토리 체크에서 해시 확인으로 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `--verbose-table-info` CLI 플래그 추가로 상세한 데이터베이스 테이블 정보 조회 가능
  * npm 의존성 캐싱 지원으로 부트스트랩 속도 향상
  * 서비스 실패 감지 및 보고 개선

* **변경 사항**
  * SQLite 지원 제거 (PostgreSQL만 지원)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->