### PR TITLE
IoT 환기,관수/양액, 조명, 차광/보온 기능 수동 제어

### DIFF
--- a/.bkit-memory.json
+++ b/.bkit-memory.json
@@ -1,11 +1,11 @@
 {
-  "feature": "iot-ai-agent-automation",
-  "phase": "plan",
+  "feature": "iot-manual-control",
+  "phase": "completed",
   "level": "Dynamic",
   "teamMode": true,
-  "startedAt": "2026-04-14T00:00:00Z",
-  "iterationCount": 0,
-  "matchRate": 0,
+  "startedAt": "2026-04-16T00:00:00Z",
+  "iterationCount": 1,
+  "matchRate": 98,
   "priorWork": {
     "feature": "farmos_review_analysis",
     "archivedAt": "2026-04-13",

--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -3,9 +3,6 @@ setlocal
 chcp 65001 >nul
 cd /d "%~dp0"
 
-rem -- PostgreSQL bin 경로 추가 (버전에 맞게 수정) --
-set "PATH=C:\Program Files\PostgreSQL\18\bin;%PATH%"
-
 where python >nul 2>&1
 if errorlevel 1 (
   echo [Bootstrap] ERROR: python not found in PATH.

--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -3,6 +3,9 @@ setlocal
 chcp 65001 >nul
 cd /d "%~dp0"
 
+rem -- PostgreSQL bin 경로 추가 (버전에 맞게 수정) --
+set "PATH=C:\Program Files\PostgreSQL\18\bin;%PATH%"
+
 where python >nul 2>&1
 if errorlevel 1 (
   echo [Bootstrap] ERROR: python not found in PATH.

--- a/docs/01-plan/features/iot-manual-control.plan.md
+++ b/docs/01-plan/features/iot-manual-control.plan.md
@@ -1,0 +1,696 @@
+# IoT Manual Control Planning Document
+
+> **Summary**: ESP8266 물리 버튼 + 프론트엔드 UI를 통한 양방향 수동 제어 시스템. LED 상태가 프론트엔드와 실시간 동기화.
+>
+> **Project**: FarmOS - IoT Manual Control
+> **Version**: 0.1.0
+> **Author**: clover0309
+> **Date**: 2026-04-16
+> **Status**: Draft
+> **Prerequisites**: IoT Relay Server 정상 동작 (iot.lilpa.moe:9000), ESP8266 센서 데이터 수신 정상
+
+---
+
+## Executive Summary
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | 현재 IoT 시스템은 센서 모니터링만 가능하고, AI Agent의 가상 제어 상태 표시만 있을 뿐 실제 하드웨어를 수동으로 조작하거나 물리 버튼으로 제어하는 기능이 없다. |
+| **Solution** | 프론트엔드에 4대 제어(환기/관수/조명/차광) 수동 조작 UI 추가 + ESP8266에 물리 버튼과 LED를 추가하여 양방향 제어 구현. Relay Server가 중계 허브 역할. |
+| **Function/UX Effect** | 대시보드에서 슬라이더/토글로 직접 제어, ESP8266 버튼으로 물리적 토글, LED 상태가 양쪽에 실시간 반영되어 직관적인 농장 제어 UX 제공. |
+| **Core Value** | 1인 농업인이 PC 대시보드 또는 현장 버튼 모두에서 즉시 제어 가능한 통합 제어 경험. 자동/수동 제어의 유기적 전환. |
+
+---
+
+## Context Anchor
+
+> Auto-generated from Executive Summary. Propagated to Design/Do documents for context continuity.
+
+| Key | Value |
+|-----|-------|
+| **WHY** | 센서 모니터링만 가능한 IoT 시스템에 실제 수동 제어 + 물리 버튼 제어를 추가하여 양방향 하드웨어 연동 달성 |
+| **WHO** | FarmOS 사용자 (1인 농업인), 대시보드에서 원격 제어 + 현장에서 버튼 제어 |
+| **RISK** | ESP8266의 HTTP-only 통신 제약 (TLS 미지원), 폴링 지연 (최대 수 초), Relay Server 코드 변경 시 N100 재배포 필요 |
+| **SUCCESS** | 프론트엔드 토글 -> 5초 내 ESP8266 LED 반응, ESP8266 버튼 -> 2초 내 프론트엔드 상태 반영, 4대 제어 항목 모두 양방향 동작 |
+| **SCOPE** | Phase 1: 환기 -> Phase 2: 관수/양액 -> Phase 3: 조명 -> Phase 4: 차광/보온 (순차 구현, 각 단계 사용자 테스트 통과 후 진행) |
+
+---
+
+## 하드웨어 현황 (Critical Constraint)
+
+> **현재 ESP8266에는 DHT11(D4) + KY-018 LDR(A0)만 연결되어 있습니다.**
+> **버튼/LED 회로는 미구성 상태이며, 추후 브레드보드에서 구성 예정입니다.**
+
+이에 따라 **Software-First 전략**을 채택합니다:
+1. Relay Server API + Frontend UI + 시뮬레이션 모드를 먼저 구현
+2. 프론트엔드 시뮬레이션 모드로 양방향 흐름을 검증
+3. 회로 구성 후 ESP8266 펌웨어에서 LED/버튼 핀을 활성화
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+FarmOS IoT 시스템에 **수동 제어 기능**을 추가하여 사용자가 프론트엔드 대시보드와 ESP8266 물리 버튼 두 경로로 4대 제어 항목(환기/관수/조명/차광)을 직접 조작하고, 제어 상태가 양방향으로 실시간 동기화되는 시스템을 구축한다.
+
+### 1.2 Background
+
+- **현재 상태**: 센서 4종 모니터링(온도, 습도, 조도, 토양수분 가상계산) + AI Agent 가상 제어 상태 표시만 구현
+- **수동 관수 트리거**만 존재 (`POST /api/v1/irrigation/trigger`), 이마저도 이벤트 기록용이며 하드웨어와 연동되지 않음
+- AI Agent는 가상 제어 상태만 표시 (실제 하드웨어 제어 없음, "가상 제어" 배지로 표시)
+- ESP8266은 현재 센서 데이터 전송(HTTP POST, 30초 간격)만 수행하는 단방향 디바이스
+- **요구**: 프론트엔드 UI 제어 + ESP8266 물리 버튼 제어 + LED 양방향 동기화
+
+### 1.3 Related Documents
+
+- IoT Relay Server 계획: `docs/iot-relay-server-plan.md`
+- IoT AI Agent Automation 계획: `docs/01-plan/features/iot-ai-agent-automation.plan.md`
+- ESP8266 작업 목록: `docs/esp8266-todo.md`
+
+---
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- [ ] 프론트엔드 수동 제어 UI (4대 제어 항목: 환기/관수/조명/차광)
+- [ ] ESP8266 물리 버튼 추가 + 버튼 이벤트를 Relay Server로 전송
+- [ ] ESP8266 LED 출력 (제어 상태 시각화)
+- [ ] Relay Server에 제어 명령 저장/조회/큐잉 API 추가
+- [ ] ESP8266 -> Relay Server -> Frontend (SSE) 상태 동기화 (버튼 -> LED -> 프론트엔드)
+- [ ] Frontend -> Relay Server -> ESP8266 (폴링) 명령 전달 (프론트엔드 -> LED)
+- [ ] 환기 -> 관수 -> 조명 -> 차광 순서 순차 구현
+
+### 2.2 Out of Scope
+
+- 실제 모터/밸브/보광등/차광막 하드웨어 연동 (LED로 시뮬레이션)
+- AI Agent의 자동 제어 연동 (이번 피처는 수동 제어에 집중)
+- TLS/HTTPS 통신 (ESP8266 하드웨어 제약)
+- 로컬 Backend 서버 변경 (Relay Server에서 제어 명령 관리)
+- 다중 ESP8266 디바이스 지원
+
+---
+
+## 3. Requirements
+
+### 3.1 Functional Requirements
+
+| ID | Requirement | Priority | Status |
+|----|-------------|----------|--------|
+| FR-01 | 프론트엔드에서 환기 제어(창문 개폐율 슬라이더, 팬 속도 조절) | High | Pending |
+| FR-02 | 프론트엔드에서 관수 제어(밸브 열림/닫힘 토글) | High | Pending |
+| FR-03 | 프론트엔드에서 조명 제어(ON/OFF 토글, 밝기 슬라이더) | High | Pending |
+| FR-04 | 프론트엔드에서 차광/보온 제어(차광막 %, 보온 % 슬라이더) | High | Pending |
+| FR-05 | ESP8266에 물리 버튼 추가, 버튼으로 제어 항목 토글 | High | Pending |
+| FR-06 | ESP8266 버튼 누르면 LED ON/OFF, 해당 상태를 Relay Server로 전송 | High | Pending |
+| FR-07 | Relay Server가 ESP8266 상태를 SSE로 프론트엔드에 브로드캐스트 | High | Pending |
+| FR-08 | 프론트엔드 제어 명령 -> Relay Server -> ESP8266이 폴링하여 수신 | High | Pending |
+| FR-09 | ESP8266이 폴링으로 받은 명령에 따라 LED 상태 변경 | High | Pending |
+| FR-10 | 제어 명령 이력 저장 및 조회 | Medium | Pending |
+| FR-11 | 수동 제어와 AI Agent 자동 제어 상태 구분 표시 | Medium | Pending |
+
+### 3.2 Non-Functional Requirements
+
+| Category | Criteria | Measurement Method |
+|----------|----------|-------------------|
+| Latency (Frontend -> ESP8266) | 프론트엔드 명령 후 ESP8266 LED 반응 5초 이내 | ESP8266 폴링 주기(2~3초) + 네트워크 왕복 시간 측정 |
+| Latency (ESP8266 -> Frontend) | 버튼 누름 후 프론트엔드 상태 반영 2초 이내 | SSE 이벤트 수신 타이밍 측정 |
+| Reliability | ESP8266 WiFi 끊김 시 자동 재연결, 명령 유실 방지 | 네트워크 차단 후 복구 테스트 |
+| Compatibility | ESP8266 (NodeMCU v1.0), Arduino IDE 호환 | 기존 핀 배치 유지, 추가 핀 사용 |
+| Scalability | Relay Server 인메모리 명령 큐 1000건 제한 | 메모리 사용량 모니터링 |
+
+---
+
+## 4. Success Criteria
+
+### 4.1 Definition of Done
+
+- [ ] 프론트엔드에서 환기/관수/조명/차광 4개 제어 UI 동작
+- [ ] ESP8266 물리 버튼 누르면 LED 토글 + Relay Server에 상태 전송
+- [ ] Relay Server -> SSE -> 프론트엔드에 버튼 상태 실시간 반영
+- [ ] 프론트엔드 제어 명령 -> Relay Server -> ESP8266 폴링 -> LED 반응
+- [ ] 양방향 동기화: 프론트엔드 상태와 ESP8266 LED 상태 일치
+- [ ] 각 제어 항목별 사용자 실 테스트 통과
+
+### 4.2 Quality Criteria
+
+- [ ] ESP8266 폴링 지연 5초 이내
+- [ ] SSE 이벤트 전달 2초 이내
+- [ ] WiFi 재연결 후 상태 정합성 유지
+- [ ] Relay Server 재시작 후 마지막 제어 상태 복원
+
+---
+
+## 5. Risks and Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| ESP8266 폴링 지연으로 프론트엔드-LED 상태 불일치 | Medium | High | 폴링 주기 2~3초로 설정, 프론트엔드에 "명령 전송 중..." 상태 표시 |
+| ESP8266 메모리 부족 (HTTP 서버 + 클라이언트 동시 운영) | High | Medium | HTTP 서버 대신 폴링 방식 채택 (ESP8266이 주기적으로 명령 조회) |
+| Relay Server 재시작 시 제어 상태 초기화 | Medium | Medium | 마지막 제어 상태를 파일/JSON으로 영속화 |
+| N100 서버 코드 변경 시 재배포 필요 | Medium | High | 변경 범위 최소화, 명확한 재배포 안내 절차 |
+| WiFi 불안정으로 ESP8266 연결 끊김 | Medium | Medium | 자동 재연결 로직, 연결 끊김 시 마지막 상태 유지 |
+| 버튼 디바운싱 미처리로 중복 명령 전송 | Low | Medium | 하드웨어/소프트웨어 디바운싱 200ms 적용 |
+| ESP8266 핀 부족 (센서 + 버튼 + LED) | Low | Low | NodeMCU 사용 가능 핀 확인: D1~D8 중 D4(DHT11), A0(LDR) 외 6개 여유 |
+
+---
+
+## 6. Current System Analysis
+
+### 6.1 현재 아키텍처
+
+```
+ESP8266 (DHT11 + KY-018 LDR)
+    | HTTP POST /api/v1/sensors (30초 간격, X-API-Key: farmos-iot-default-key)
+    v
+IoT Relay Server (iot.lilpa.moe:9000, FastAPI, Docker on N100)
+    |- SSE broadcast -> Frontend (sensor, alert, irrigation events)
+    |- REST API -> Frontend (latest, history, alerts, irrigation/events)
+    |- AI Agent API -> Frontend (status, decisions, override, crop-profile)
+    v
+Frontend (React + Vite, localhost:5173)
+    |- useSensorData.ts: SSE + 60초 전체 동기화
+    |- useAIAgent.ts: 30초 폴링
+    |- IoTDashboardPage.tsx: 센서 카드 + 차트 + 관수 이력 + 알림
+    |- AIAgentPanel.tsx: AI 제어 상태 표시 (가상 제어)
+```
+
+### 6.2 현재 통신 흐름 (단방향)
+
+```
+ESP8266 ----POST----> Relay Server ----SSE----> Frontend
+                                   <---GET----- Frontend (폴링/직접 요청)
+```
+
+- ESP8266은 **전송만** 수행 (수신 기능 없음)
+- Relay Server -> ESP8266 방향 통신 경로 없음
+- Frontend -> Relay Server -> ESP8266 명령 전달 경로 없음
+
+### 6.3 ESP8266 현재 핀 사용
+
+| 핀 | 용도 | 비고 |
+|----|------|------|
+| D4 (GPIO2) | DHT11 센서 | 온도/습도 |
+| A0 | KY-018 LDR | 조도 (아날로그 입력) |
+| - | WiFi (내장) | HTTP POST 전송 |
+
+**사용 가능 핀**: D0, D1, D2, D3, D5, D6, D7, D8 (8개)
+
+### 6.4 Relay Server 현재 API (iot.lilpa.moe:9000)
+
+| Method | Path | 인증 | 용도 |
+|--------|------|------|------|
+| POST | `/api/v1/sensors` | X-API-Key | ESP8266 센서 수신 |
+| GET | `/api/v1/sensors/latest` | - | 최신 센서값 |
+| GET | `/api/v1/sensors/history` | - | 시계열 데이터 |
+| GET | `/api/v1/sensors/alerts` | - | 알림 목록 |
+| GET | `/api/v1/sensors/stream` | - | SSE 스트림 |
+| POST | `/api/v1/irrigation/trigger` | - | 수동 관수 |
+| GET | `/api/v1/irrigation/events` | - | 관수 이력 |
+| GET | `/api/v1/ai-agent/status` | - | AI Agent 상태 |
+| POST | `/api/v1/ai-agent/toggle` | - | AI Agent ON/OFF |
+| PUT | `/api/v1/ai-agent/crop-profile` | - | 작물 프로필 수정 |
+| POST | `/api/v1/ai-agent/override` | - | 수동 오버라이드 |
+
+---
+
+## 7. Communication Protocol Design
+
+### 7.1 목표 아키텍처 (양방향)
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │     IoT Relay Server (iot.lilpa.moe)      │
+                    │                                          │
+   ESP8266 -------->│  POST /sensors (센서 데이터)              │------> SSE -------> Frontend
+   (30초 간격)       │  POST /control/report (버튼/LED 상태)    │  (sensor event)
+                    │                                          │
+   ESP8266 <------->│  GET  /control/commands (폴링, 2~3초)    │<------ POST -------- Frontend
+   (폴링 수신)       │  POST /control (프론트엔드 명령)         │  (제어 명령 전송)
+                    │                                          │
+                    │  [인메모리 제어 상태 저장소]               │------> SSE -------> Frontend
+                    │  - pending_commands queue                │  (control event)
+                    │  - current_control_state                 │
+                    └──────────────────────────────────────────┘
+```
+
+### 7.2 통신 프로토콜 상세
+
+#### 7.2.1 Frontend -> ESP8266 (프론트엔드 제어 명령)
+
+```
+1. Frontend: POST /api/v1/control
+   Body: { "control_type": "ventilation", "action": { "window_open_pct": 70 }, "source": "manual" }
+
+2. Relay Server: 명령을 pending_commands 큐에 저장 + current_control_state 업데이트
+
+3. Relay Server: SSE로 "control" 이벤트 브로드캐스트 (프론트엔드 즉시 반영)
+
+4. ESP8266: GET /api/v1/control/commands (2~3초 폴링)
+   Response: { "commands": [{ "control_type": "ventilation", "action": { "window_open_pct": 70 } }] }
+
+5. ESP8266: 명령 수신 후 LED 상태 변경 + POST /api/v1/control/ack (수신 확인)
+```
+
+#### 7.2.2 ESP8266 -> Frontend (버튼 제어)
+
+```
+1. ESP8266: 물리 버튼 누름 (디바운싱 200ms)
+
+2. ESP8266: LED 상태 즉시 토글
+
+3. ESP8266: POST /api/v1/control/report
+   Body: { "device_id": "esp8266-01", "control_type": "ventilation", "state": { "led_on": true, "window_open_pct": 100 }, "source": "button" }
+
+4. Relay Server: current_control_state 업데이트
+
+5. Relay Server: SSE "control" 이벤트 브로드캐스트 -> Frontend 즉시 반영
+```
+
+### 7.3 제어 상태 데이터 모델
+
+```python
+# Relay Server: 인메모리 제어 상태
+control_state = {
+    "ventilation": {
+        "window_open_pct": 0,    # 0~100
+        "fan_speed": 0,          # RPM
+        "led_on": False,         # ESP8266 LED 상태
+        "source": "manual",      # manual | button | ai
+        "updated_at": "ISO8601"
+    },
+    "irrigation": {
+        "valve_open": False,
+        "led_on": False,
+        "source": "manual",
+        "updated_at": "ISO8601"
+    },
+    "lighting": {
+        "on": False,
+        "brightness_pct": 0,
+        "led_on": False,
+        "source": "manual",
+        "updated_at": "ISO8601"
+    },
+    "shading": {
+        "shade_pct": 0,
+        "insulation_pct": 0,
+        "led_on": False,
+        "source": "manual",
+        "updated_at": "ISO8601"
+    }
+}
+
+# Pending commands queue (ESP8266이 폴링으로 가져감)
+pending_commands = deque(maxlen=100)
+```
+
+### 7.4 Relay Server 신규 API
+
+| Method | Path | 인증 | 용도 |
+|--------|------|------|------|
+| POST | `/api/v1/control` | - | 프론트엔드 -> 제어 명령 전송 |
+| GET | `/api/v1/control/state` | - | 현재 전체 제어 상태 조회 |
+| GET | `/api/v1/control/commands` | X-API-Key | ESP8266 -> 대기 명령 폴링 |
+| POST | `/api/v1/control/report` | X-API-Key | ESP8266 -> 버튼/LED 상태 보고 |
+| POST | `/api/v1/control/ack` | X-API-Key | ESP8266 -> 명령 수신 확인 |
+
+### 7.5 SSE 이벤트 확장
+
+기존 SSE 이벤트 타입에 `control` 이벤트 추가:
+
+```
+event: control
+data: {
+    "control_type": "ventilation",
+    "state": { "window_open_pct": 70, "fan_speed": 0, "led_on": true },
+    "source": "button",
+    "timestamp": "2026-04-16T14:30:00Z"
+}
+```
+
+### 7.6 ESP8266 폴링 시퀀스
+
+```
+기존 loop (30초 간격):
+    1. 센서 읽기 -> POST /sensors
+
+신규 loop (2~3초 간격, 별도 타이밍):
+    1. GET /control/commands
+    2. 새 명령 있으면 -> LED 상태 변경 + POST /control/ack
+    3. 버튼 상태 확인 (인터럽트 플래그)
+    4. 버튼 눌렸으면 -> LED 토글 + POST /control/report
+```
+
+---
+
+## 8. ESP8266 Hardware Design
+
+### 8.1 추가 하드웨어
+
+| 부품 | 수량 | 용도 | 비고 |
+|------|------|------|------|
+| 택트 스위치 (Tact Switch) | 1~4개 | 제어 항목 토글 | Phase별 1개씩 추가 |
+| LED | 1~4개 | 제어 상태 표시 | 각 제어 항목별 1개 |
+| 저항 (220ohm) | 1~4개 | LED 전류 제한 | LED당 1개 |
+| 저항 (10Kohm) | 1~4개 | 버튼 풀다운 | 버튼당 1개 |
+
+### 8.2 핀 배정 계획
+
+| 핀 | 기존/신규 | 용도 | Phase |
+|----|----------|------|-------|
+| D4 | 기존 | DHT11 센서 | - |
+| A0 | 기존 | KY-018 LDR | - |
+| D1 | 신규 | 환기 LED | Phase 1 |
+| D2 | 신규 | 환기 버튼 | Phase 1 |
+| D5 | 신규 | 관수 LED | Phase 2 |
+| D6 | 신규 | 관수 버튼 | Phase 2 |
+| D7 | 신규 | 조명 LED | Phase 3 |
+| D8 | 신규 | 조명 버튼 | Phase 3 |
+| D3 | 신규 | 차광 LED | Phase 4 |
+| D0 | 신규 | 차광 버튼 | Phase 4 |
+
+### 8.3 버튼 디바운싱
+
+```cpp
+// 소프트웨어 디바운싱 (인터럽트 + millis)
+#define DEBOUNCE_MS 200
+
+volatile bool buttonPressed = false;
+unsigned long lastButtonTime = 0;
+
+ICACHE_RAM_ATTR void handleButtonISR() {
+    if (millis() - lastButtonTime > DEBOUNCE_MS) {
+        buttonPressed = true;
+        lastButtonTime = millis();
+    }
+}
+```
+
+---
+
+## 9. Implementation Phases
+
+### Phase 1: 환기 (Ventilation) -- 기반 인프라 + 첫 번째 제어
+
+**목표**: 전체 양방향 통신 인프라 구축 + 환기 제어 1건 완성
+
+**Relay Server 변경**:
+1. [ ] 제어 상태 인메모리 저장소 (`control_store.py`)
+2. [ ] 제어 명령 API 엔드포인트 (`POST /control`, `GET /control/state`)
+3. [ ] ESP8266 폴링 엔드포인트 (`GET /control/commands`, `POST /control/ack`)
+4. [ ] ESP8266 상태 보고 엔드포인트 (`POST /control/report`)
+5. [ ] SSE에 `control` 이벤트 타입 추가
+
+**ESP8266 변경**:
+6. [ ] 환기 버튼 (D2) + LED (D1) 하드웨어 배선
+7. [ ] 버튼 인터럽트 + 디바운싱 구현
+8. [ ] LED 제어 로직 (토글)
+9. [ ] 폴링 루프 (2~3초 간격, GET /control/commands)
+10. [ ] 명령 수신 시 LED 상태 변경 + ACK 전송
+11. [ ] 버튼 누름 시 POST /control/report
+
+**Frontend 변경**:
+12. [ ] `useManualControl` 훅 (제어 상태 관리 + SSE 수신)
+13. [ ] 환기 제어 UI (창문 개폐율 슬라이더, 팬 속도)
+14. [ ] SSE `control` 이벤트 수신 처리 (`useSensorData.ts` 확장)
+15. [ ] 수동 제어 패널 컴포넌트 (`ManualControlPanel.tsx`)
+
+**테스트 기준**:
+- [T1-1] 프론트엔드에서 환기 ON -> ESP8266 LED 점등 (5초 이내)
+- [T1-2] ESP8266 버튼 누름 -> LED 토글 -> 프론트엔드 상태 반영 (2초 이내)
+- [T1-3] 창문 개폐율 슬라이더 조작 -> 값이 프론트엔드와 Relay Server에서 일치
+
+### Phase 2: 관수/양액 (Irrigation)
+
+**목표**: Phase 1 인프라 위에 관수 제어 추가
+
+**ESP8266 변경**:
+1. [ ] 관수 버튼 (D6) + LED (D5) 하드웨어 배선
+2. [ ] 관수 버튼/LED 로직 추가
+
+**Frontend 변경**:
+3. [ ] 관수 제어 UI (밸브 열림/닫힘 토글)
+4. [ ] `useManualControl` 훅에 관수 제어 추가
+5. [ ] 기존 관수 이벤트와 수동 제어 이벤트 통합 표시
+
+**Relay Server 변경**:
+6. [ ] 관수 제어 상태 관리 추가
+
+**테스트 기준**:
+- [T2-1] 프론트엔드에서 밸브 열림 -> ESP8266 관수 LED 점등
+- [T2-2] ESP8266 관수 버튼 -> LED 토글 -> 프론트엔드 밸브 상태 반영
+- [T2-3] 관수 이벤트 이력에 수동 제어 기록 표시
+
+### Phase 3: 조명 (Lighting)
+
+**목표**: 조명 ON/OFF + 밝기 조절
+
+**ESP8266 변경**:
+1. [ ] 조명 버튼 (D8) + LED (D7) 하드웨어 배선
+2. [ ] 조명 버튼/LED 로직 (PWM으로 밝기 시뮬레이션 가능)
+
+**Frontend 변경**:
+3. [ ] 조명 제어 UI (ON/OFF 토글 + 밝기 슬라이더)
+4. [ ] `useManualControl` 훅에 조명 제어 추가
+
+**Relay Server 변경**:
+5. [ ] 조명 제어 상태 관리 추가
+
+**테스트 기준**:
+- [T3-1] 프론트엔드 조명 ON -> ESP8266 조명 LED 점등
+- [T3-2] 밝기 조절 -> ESP8266 LED PWM 밝기 변화 (선택)
+- [T3-3] ESP8266 조명 버튼 -> 프론트엔드 즉시 반영
+
+### Phase 4: 차광/보온 (Shading)
+
+**목표**: 차광막 %, 보온 % 제어
+
+**ESP8266 변경**:
+1. [ ] 차광 버튼 (D0) + LED (D3) 하드웨어 배선
+2. [ ] 차광 버튼/LED 로직
+
+**Frontend 변경**:
+3. [ ] 차광/보온 제어 UI (차광막 % 슬라이더, 보온 % 슬라이더)
+4. [ ] `useManualControl` 훅에 차광/보온 제어 추가
+
+**Relay Server 변경**:
+5. [ ] 차광/보온 제어 상태 관리 추가
+
+**테스트 기준**:
+- [T4-1] 프론트엔드 차광막 50% -> Relay Server 상태 업데이트 + ESP8266 LED 점등
+- [T4-2] ESP8266 차광 버튼 -> 프론트엔드 즉시 반영
+- [T4-3] 4대 제어 항목 모두 동시 동작, 상태 정합성 유지
+
+---
+
+## 10. Impact Analysis
+
+### 10.1 Changed Resources
+
+| Resource | Type | Change Description |
+|----------|------|--------------------|
+| Relay Server (iot.lilpa.moe:9000) | Server API | 제어 명령 API 5개 추가, SSE에 control 이벤트 추가 |
+| ESP8266 펌웨어 (.ino) | Firmware | 버튼/LED 핀 추가, 폴링 루프 추가, 기존 센서 루프 유지 |
+| Frontend useSensorData.ts | Hook | SSE control 이벤트 수신 추가 |
+| Frontend IoTDashboardPage.tsx | Component | 수동 제어 패널 영역 추가 |
+| Frontend types/index.ts | Types | ManualControlState, ControlCommand 타입 추가 |
+
+### 10.2 Current Consumers
+
+| Resource | Operation | Code Path | Impact |
+|----------|-----------|-----------|--------|
+| Relay Server SSE | READ | `useSensorData.ts` -> EventSource | sensor/alert/irrigation 이벤트 유지, control 이벤트 추가 |
+| Relay Server AI Agent API | READ | `useAIAgent.ts` -> fetch polling | 변경 없음 (AI Agent는 별도 상태) |
+| ESP8266 센서 POST | WRITE | `.ino` -> HTTP POST /sensors | 30초 간격 유지, 별도 폴링 루프 추가 |
+| Frontend AIAgentPanel | READ | `AIAgentPanel.tsx` | AI 가상 제어 표시 유지, 수동 제어와 UI 영역 분리 |
+
+### 10.3 Verification
+
+- [ ] 기존 센서 데이터 수집 흐름 (ESP8266 -> Relay -> SSE -> Frontend) 영향 없음
+- [ ] AI Agent 상태/판단 API 영향 없음
+- [ ] 관수 이벤트 API 하위 호환 유지
+- [ ] 프론트엔드 기존 차트/알림 UI 영향 없음
+
+---
+
+## 11. Architecture Considerations
+
+### 11.1 Project Level Selection
+
+| Level | Characteristics | Recommended For | Selected |
+|-------|-----------------|-----------------|:--------:|
+| **Starter** | Simple structure | Static sites, portfolios | - |
+| **Dynamic** | Feature-based modules, BaaS integration | Web apps with backend, SaaS MVPs | **Selected** |
+| **Enterprise** | Strict layer separation, microservices | High-traffic systems | - |
+
+### 11.2 Key Architectural Decisions
+
+| Decision | Options | Selected | Rationale |
+|----------|---------|----------|-----------|
+| ESP8266 -> Relay 양방향 통신 | (A) WebSocket / (B) ESP8266 HTTP Server / (C) 폴링 | **(C) 폴링** | ESP8266 메모리 제약 (WebSocket 라이브러리 무거움), HTTP 서버 병행 시 안정성 이슈. 폴링이 가장 안정적. |
+| 제어 상태 저장 | (A) PostgreSQL / (B) Redis / (C) 인메모리 + 파일 백업 | **(C) 인메모리 + 파일** | Relay Server가 인메모리 기반, DB 의존 없음. 파일 백업으로 재시작 시 복구. |
+| 프론트엔드 제어 수신 | (A) 폴링 / (B) SSE (기존 확장) / (C) WebSocket | **(B) SSE 확장** | 기존 SSE 인프라 활용. control 이벤트 타입 추가만으로 구현 가능. |
+| 순차 구현 전략 | (A) 4개 동시 / (B) 환기 먼저 + 나머지 순차 | **(B) 순차** | 하드웨어 테스트가 필요하므로 1개씩 완성 후 검증. |
+| ESP8266 폴링 주기 | (A) 1초 / (B) 2~3초 / (C) 5초 | **(B) 2~3초** | 응답성과 Relay Server 부하 균형. |
+| 제어 명령 큐 방식 | (A) FIFO 큐 + ACK / (B) 최신 상태만 덮어쓰기 | **(B) 최신 상태 덮어쓰기** | ESP8266 폴링 간격 동안 여러 명령 시 최신 상태만 반영하면 충분. ACK로 수신 확인. |
+
+### 11.3 Clean Architecture Approach
+
+```
+Selected Level: Dynamic
+
+제어 흐름:
+┌────────────────────────────────────────────────────────────────────┐
+│ Frontend (React)                                                  │
+│   src/modules/iot/ManualControlPanel.tsx  (UI)                    │
+│   src/hooks/useManualControl.ts          (State + API)            │
+│   src/hooks/useSensorData.ts             (SSE 확장)               │
+│   src/types/index.ts                     (Types 추가)             │
+├────────────────────────────────────────────────────────────────────┤
+│ Relay Server (FastAPI, N100)                                      │
+│   app/control_store.py     (인메모리 제어 상태 + 명령 큐)           │
+│   app/control_routes.py    (제어 API 라우터)                       │
+│   app/main.py              (라우터 등록 + SSE control 이벤트)       │
+├────────────────────────────────────────────────────────────────────┤
+│ ESP8266 (Arduino C++)                                             │
+│   DH11_KY018_WiFi.ino     (기존 센서 루프 유지 + 폴링/버튼 루프)    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 12. Convention Prerequisites
+
+### 12.1 Existing Project Conventions
+
+- [x] TypeScript strict mode (Frontend)
+- [x] React functional components + hooks pattern
+- [x] Pydantic schemas (Backend/Relay Server)
+- [x] FastAPI router pattern
+- [ ] ESLint/Prettier 설정 (미확인)
+- [x] ESP8266 Arduino IDE 환경
+
+### 12.2 Environment Variables Needed
+
+| Variable | Purpose | Scope | To Be Created |
+|----------|---------|-------|:-------------:|
+| `IOT_API_KEY` | ESP8266 인증 (기존) | Relay Server | Existing |
+| `VITE_IOT_API_URL` | Relay Server URL (프론트엔드) | Frontend | May need |
+| `CONTROL_STATE_FILE` | 제어 상태 백업 파일 경로 | Relay Server | New |
+
+---
+
+## 13. Deployment Notes
+
+### 13.1 Relay Server (N100) 변경 시 절차
+
+```
+1. iot_relay_server/ 코드 수정 (로컬에서)
+2. 수정된 코드를 N100 서버에 업로드 (scp / git push + pull)
+3. N100에서 Docker 재빌드 + 재시작:
+   cd iot_relay_server
+   docker compose down
+   docker compose up -d --build
+4. 헬스체크: curl http://iot.lilpa.moe:9000/health
+```
+
+> **중요**: N100 서버 직접 조작 금지. 사용자에게 위 절차 안내 후 대기.
+
+### 13.2 ESP8266 변경 시 절차
+
+```
+1. DH11_KY018_WiFi.ino 코드 수정
+2. 브레드보드에 버튼/LED 배선 추가
+3. Arduino IDE에서 컴파일 + 업로드
+4. 시리얼 모니터로 동작 확인
+```
+
+### 13.3 Frontend 변경 시 절차
+
+```
+1. 코드 수정 (로컬)
+2. npm run dev (자동 핫 리로드)
+3. 브라우저에서 IoT 대시보드 확인
+```
+
+---
+
+## 14. Testing Strategy
+
+### 14.1 단위 테스트 (각 Phase)
+
+| 대상 | 테스트 방법 | 도구 |
+|------|-----------|------|
+| Relay Server API | curl/httpie로 엔드포인트 호출 | Terminal |
+| SSE 이벤트 | curl 스트리밍 수신 확인 | Terminal |
+| ESP8266 폴링 | 시리얼 모니터 + Relay Server 로그 | Arduino IDE |
+| Frontend UI | 브라우저 수동 테스트 | Chrome DevTools |
+
+### 14.2 통합 테스트 (Phase별 완료 시)
+
+```
+시나리오 A: Frontend -> ESP8266
+1. 프론트엔드에서 환기 ON 버튼 클릭
+2. Relay Server에 POST /control 확인 (로그)
+3. ESP8266이 GET /control/commands로 명령 수신 (시리얼 모니터)
+4. ESP8266 LED 점등 확인 (실물)
+5. ESP8266이 POST /control/ack 전송 확인
+
+시나리오 B: ESP8266 -> Frontend
+1. ESP8266 물리 버튼 누름
+2. ESP8266 LED 토글 확인 (실물)
+3. ESP8266이 POST /control/report 전송 (시리얼 모니터)
+4. Relay Server SSE에 control 이벤트 발생 (curl 확인)
+5. 프론트엔드 제어 상태 업데이트 확인 (브라우저)
+
+시나리오 C: 동시성
+1. 프론트엔드에서 환기 ON
+2. 즉시 ESP8266 버튼으로 환기 OFF
+3. 최종 상태가 프론트엔드와 ESP8266에서 일치하는지 확인
+```
+
+### 14.3 ESP8266 없이 사전 테스트
+
+```bash
+# Relay Server API 테스트 (curl)
+
+# 1. 제어 명령 전송 (프론트엔드 시뮬레이션)
+curl -X POST http://iot.lilpa.moe:9000/api/v1/control \
+  -H "Content-Type: application/json" \
+  -d '{"control_type":"ventilation","action":{"window_open_pct":70},"source":"manual"}'
+
+# 2. 제어 상태 조회
+curl http://iot.lilpa.moe:9000/api/v1/control/state
+
+# 3. 대기 명령 조회 (ESP8266 시뮬레이션)
+curl -H "X-API-Key: farmos-iot-default-key" \
+  http://iot.lilpa.moe:9000/api/v1/control/commands
+
+# 4. 버튼 상태 보고 (ESP8266 시뮬레이션)
+curl -X POST http://iot.lilpa.moe:9000/api/v1/control/report \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: farmos-iot-default-key" \
+  -d '{"device_id":"esp8266-01","control_type":"ventilation","state":{"led_on":true,"window_open_pct":100},"source":"button"}'
+
+# 5. SSE 스트림 (control 이벤트 수신 확인)
+curl -N http://iot.lilpa.moe:9000/api/v1/sensors/stream
+```
+
+---
+
+## 15. Next Steps
+
+1. [ ] Write design document (`iot-manual-control.design.md`) -- 3가지 설계안 비교
+2. [ ] Relay Server `iot_relay_server/` 코드 확인 (N100에서 현재 버전 파악)
+3. [ ] Phase 1 (환기) 구현 시작
+4. [ ] Phase 1 사용자 테스트 통과 후 Phase 2 진행
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-04-16 | Initial draft | clover0309 |

--- a/docs/02-design/features/iot-manual-control.design.md
+++ b/docs/02-design/features/iot-manual-control.design.md
@@ -1,0 +1,940 @@
+# IoT Manual Control Design Document
+
+> **Feature**: iot-manual-control
+> **Architecture**: Option C — Pragmatic Balance
+> **Plan Reference**: `docs/01-plan/features/iot-manual-control.plan.md`
+> **Date**: 2026-04-16
+> **Status**: Draft
+
+---
+
+## Context Anchor
+
+| Key | Value |
+|-----|-------|
+| **WHY** | 센서 모니터링만 가능한 IoT 시스템에 실제 수동 제어 + 물리 버튼 제어를 추가하여 양방향 하드웨어 연동 달성 |
+| **WHO** | FarmOS 사용자 (1인 농업인), 대시보드에서 원격 제어 + 현장에서 버튼 제어 |
+| **RISK** | ESP8266 HTTP-only 통신 제약, 폴링 지연 (최대 수 초), Relay Server 코드 변경 시 N100 재배포 필요 |
+| **SUCCESS** | 프론트엔드 토글 → 5초 내 ESP8266 LED 반응, ESP8266 버튼 → 2초 내 프론트엔드 반영 |
+| **SCOPE** | Phase 1: 환기 → Phase 2: 관수/양액 → Phase 3: 조명 → Phase 4: 차광/보온 (순차, 테스트 후 진행) |
+
+---
+
+## 하드웨어 현황 (Critical Constraint)
+
+> **현재 ESP8266에는 DHT11(D4) + KY-018 LDR(A0)만 연결되어 있습니다.**
+> **버튼/LED 회로는 미구성 상태이며, 추후 브레드보드에서 구성 예정입니다.**
+
+이 제약에 따른 설계 전략:
+
+| 단계 | 설명 | 테스트 방식 |
+|------|------|------------|
+| **Step 1: Software-First** | Relay Server API + Frontend UI + 시뮬레이션 모드 구현 | 프론트엔드 시뮬레이션 모드로 양방향 흐름 검증 |
+| **Step 2: ESP8266 펌웨어** | 폴링 루프 + 명령 수신 로직 추가 (LED/버튼 핀은 주석 처리) | curl로 `/control/commands` 폴링 시뮬레이션 |
+| **Step 3: 하드웨어 배선** | 브레드보드에 버튼 + LED + 저항 연결 | 실물 양방향 테스트 |
+
+**시뮬레이션 모드**: 프론트엔드 ManualControlPanel에 내장. ESP8266 없이도 프론트엔드가 직접 `/control/report`를 호출하여 "버튼 눌림" 이벤트를 발생시키고, SSE를 통해 UI가 반응하는 전체 흐름을 테스트할 수 있음.
+
+---
+
+## 1. Overview
+
+### 1.1 선택된 아키텍처: Option C — Pragmatic Balance
+
+- AI Agent와 수동 제어 **완전 분리** (별도 라우터, 별도 저장소, 별도 훅)
+- 시뮬레이션 모드를 ManualControlPanel 내에 토글로 내장
+- 신규 4파일 + 수정 4파일로 적정 규모
+- Phase별 점진적 활성화 (환기 → 관수 → 조명 → 차광)
+
+### 1.2 디렉토리 구조 (두 레포 걸침)
+
+```
+E:\new_my_study\himedia_FinalProject\
+│
+├── FarmOS\                                    ← Git repo (현재 작업 디렉토리)
+│   ├── frontend\src\
+│   │   ├── modules\iot\
+│   │   │   ├── IoTDashboardPage.tsx           [수정] ManualControlPanel 임포트 추가
+│   │   │   ├── AIAgentPanel.tsx               [유지] 변경 없음
+│   │   │   └── ManualControlPanel.tsx         [신규] 수동 제어 UI + 시뮬레이션 모드
+│   │   ├── hooks\
+│   │   │   ├── useSensorData.ts               [수정] SSE control 이벤트 수신 추가
+│   │   │   ├── useAIAgent.ts                  [유지] 변경 없음
+│   │   │   └── useManualControl.ts            [신규] 제어 상태 관리 + API 호출
+│   │   └── types\
+│   │       └── index.ts                       [수정] ManualControlState 등 타입 추가
+│   │
+│   └── DH11_KY018_WiFi\
+│       └── DH11_KY018_WiFi.ino               [수정] 폴링 루프 + 버튼/LED 로직 추가
+│
+└── iot_relay_server\                          ← 별도 디렉토리 (N100 Docker 배포)
+    └── app\
+        ├── main.py                            [수정] control_router 등록
+        ├── store.py                           [유지] 변경 없음 (센서 전용)
+        ├── schemas.py                         [수정] 제어 관련 스키마 추가
+        ├── control_store.py                   [신규] 제어 상태 인메모리 저장 + 명령 큐
+        └── control_routes.py                  [신규] 제어 API 5개 엔드포인트
+```
+
+---
+
+## 2. Data Model
+
+### 2.1 제어 상태 (Relay Server 인메모리)
+
+```python
+# iot_relay_server/app/control_store.py
+
+from datetime import datetime, timezone
+
+# 전체 제어 상태 — 서버 시작 시 파일에서 복원
+control_state: dict = {
+    "ventilation": {
+        "active": False,        # 환기 작동 여부
+        "window_open_pct": 0,   # 0~100
+        "fan_speed": 0,         # 0~100 RPM
+        "led_on": False,        # ESP8266 LED 상태
+        "source": "manual",     # "manual" | "button" | "ai"
+        "updated_at": None,     # ISO8601
+    },
+    "irrigation": {
+        "active": False,
+        "valve_open": False,
+        "led_on": False,
+        "source": "manual",
+        "updated_at": None,
+    },
+    "lighting": {
+        "active": False,
+        "on": False,
+        "brightness_pct": 0,    # 0~100
+        "led_on": False,
+        "source": "manual",
+        "updated_at": None,
+    },
+    "shading": {
+        "active": False,
+        "shade_pct": 0,         # 0~100
+        "insulation_pct": 0,    # 0~100
+        "led_on": False,
+        "source": "manual",
+        "updated_at": None,
+    },
+}
+
+# ESP8266이 폴링으로 가져갈 대기 명령 — 최신 상태 덮어쓰기 방식
+pending_commands: dict = {}
+# 예: {"ventilation": {"active": True, "window_open_pct": 70}, "timestamp": "..."}
+
+# 제어 이력 (최근 100건)
+control_history: list[dict] = []  # deque 대신 list + 슬라이싱
+```
+
+### 2.2 Frontend 타입 정의
+
+```typescript
+// frontend/src/types/index.ts 에 추가
+
+// 개별 제어 항목 상태
+export interface ControlItemState {
+  active: boolean;
+  led_on: boolean;
+  source: "manual" | "button" | "ai";
+  updated_at: string | null;
+}
+
+export interface VentilationState extends ControlItemState {
+  window_open_pct: number;
+  fan_speed: number;
+}
+
+export interface IrrigationControlState extends ControlItemState {
+  valve_open: boolean;
+}
+
+export interface LightingState extends ControlItemState {
+  on: boolean;
+  brightness_pct: number;
+}
+
+export interface ShadingState extends ControlItemState {
+  shade_pct: number;
+  insulation_pct: number;
+}
+
+// 전체 수동 제어 상태
+export interface ManualControlState {
+  ventilation: VentilationState;
+  irrigation: IrrigationControlState;
+  lighting: LightingState;
+  shading: ShadingState;
+}
+
+// 제어 명령 (프론트엔드 → Relay Server)
+export interface ControlCommand {
+  control_type: "ventilation" | "irrigation" | "lighting" | "shading";
+  action: Record<string, unknown>;
+  source: "manual" | "button";
+}
+
+// 제어 이벤트 (SSE로 수신)
+export interface ControlEvent {
+  control_type: string;
+  state: Record<string, unknown>;
+  source: string;
+  timestamp: string;
+}
+```
+
+### 2.3 Pydantic 스키마 (Relay Server)
+
+```python
+# iot_relay_server/app/schemas.py 에 추가
+
+class ControlCommandIn(BaseModel):
+    """프론트엔드 → 제어 명령"""
+    control_type: str = Field(pattern=r"^(ventilation|irrigation|lighting|shading)$")
+    action: dict
+    source: str = Field(default="manual", pattern=r"^(manual|button|ai)$")
+
+class ControlReportIn(BaseModel):
+    """ESP8266 → 버튼/LED 상태 보고"""
+    device_id: str
+    control_type: str = Field(pattern=r"^(ventilation|irrigation|lighting|shading)$")
+    state: dict
+    source: str = Field(default="button")
+
+class ControlAckIn(BaseModel):
+    """ESP8266 → 명령 수신 확인"""
+    device_id: str
+    acknowledged_types: list[str]
+```
+
+---
+
+## 3. API Design
+
+### 3.1 Relay Server 신규 API (control_routes.py)
+
+| # | Method | Path | Auth | Request | Response | 설명 |
+|---|--------|------|------|---------|----------|------|
+| 1 | `POST` | `/api/v1/control` | - | `ControlCommandIn` | `{ "status": "ok", "state": {...} }` | 프론트엔드 제어 명령 전송 |
+| 2 | `GET` | `/api/v1/control/state` | - | - | `ManualControlState` 전체 | 현재 제어 상태 조회 |
+| 3 | `GET` | `/api/v1/control/commands` | X-API-Key | `?device_id=esp8266-01` | `{ "commands": {...}, "timestamp": "..." }` | ESP8266 대기 명령 폴링 |
+| 4 | `POST` | `/api/v1/control/report` | X-API-Key | `ControlReportIn` | `{ "status": "ok" }` | ESP8266 버튼/LED 상태 보고 |
+| 5 | `POST` | `/api/v1/control/ack` | X-API-Key | `ControlAckIn` | `{ "status": "ok" }` | ESP8266 명령 수신 확인 (큐 클리어) |
+
+### 3.2 API 상세 흐름
+
+#### POST /api/v1/control (프론트엔드 → 제어 명령)
+
+```python
+# control_routes.py
+@control_router.post("")
+async def send_control(data: ControlCommandIn):
+    # 1. control_state 업데이트
+    update_control_state(data.control_type, data.action, data.source)
+    # 2. pending_commands에 추가 (ESP8266이 폴링으로 가져감)
+    add_pending_command(data.control_type, data.action)
+    # 3. SSE broadcast (프론트엔드 즉시 반영)
+    _broadcast("control", {
+        "control_type": data.control_type,
+        "state": control_state[data.control_type],
+        "source": data.source,
+        "timestamp": now_iso(),
+    })
+    return {"status": "ok", "state": control_state[data.control_type]}
+```
+
+#### GET /api/v1/control/commands (ESP8266 폴링)
+
+```python
+@control_router.get("/commands", dependencies=[Depends(verify_api_key)])
+async def get_pending_commands(device_id: str = Query(...)):
+    commands = get_and_clear_pending(device_id)
+    # 명령이 없으면 빈 dict 반환
+    return {"commands": commands, "timestamp": now_iso()}
+```
+
+**핵심**: ESP8266이 2~3초마다 이 엔드포인트를 호출. 새 명령이 있으면 가져가고, 없으면 빈 응답.
+
+#### POST /api/v1/control/report (ESP8266 → 버튼 상태 보고)
+
+```python
+@control_router.post("/report", dependencies=[Depends(verify_api_key)])
+async def report_control(data: ControlReportIn):
+    # 1. control_state 업데이트 (source="button")
+    update_control_state(data.control_type, data.state, data.source)
+    # 2. SSE broadcast → 프론트엔드 즉시 반영
+    _broadcast("control", {
+        "control_type": data.control_type,
+        "state": control_state[data.control_type],
+        "source": "button",
+        "timestamp": now_iso(),
+    })
+    return {"status": "ok"}
+```
+
+### 3.3 SSE 이벤트 확장
+
+기존 store.py의 `_broadcast()` 함수를 control_store.py에서도 사용.
+→ **store.py의 `_sse_subscribers` 리스트와 `_broadcast()` 함수를 공유**해야 함.
+
+```python
+# control_store.py에서 store.py의 broadcast를 import
+from app.store import _broadcast
+```
+
+SSE 이벤트 포맷:
+
+```
+event: control
+data: {
+    "control_type": "ventilation",
+    "state": {"active": true, "window_open_pct": 70, "led_on": true},
+    "source": "manual",
+    "timestamp": "2026-04-16T14:30:00Z"
+}
+```
+
+---
+
+## 4. Component Design
+
+### 4.1 ManualControlPanel.tsx
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  수동 제어                                    [시뮬레이션 모드 🔘] │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────────────┐  ┌──────────────────┐                     │
+│  │ 🌬️ 환기          │  │ 💧 관수/양액      │                     │
+│  │                  │  │                  │                     │
+│  │ [===●====] 70%   │  │ 밸브 [ON ● OFF]  │                     │
+│  │ 창문 개폐율       │  │                  │                     │
+│  │                  │  │ LED: 🟢          │                     │
+│  │ LED: 🟢          │  │ 소스: 수동        │                     │
+│  │ 소스: 수동        │  └──────────────────┘                     │
+│  └──────────────────┘                                           │
+│                                                                 │
+│  ┌──────────────────┐  ┌──────────────────┐                     │
+│  │ 💡 조명          │  │ 🛡️ 차광/보온      │                     │
+│  │                  │  │                  │                     │
+│  │ [ON ● OFF]       │  │ [===●====] 50%   │                     │
+│  │ [===●====] 80%   │  │ 차광막            │                     │
+│  │ 밝기             │  │ [===●====] 30%   │                     │
+│  │                  │  │ 보온              │                     │
+│  │ LED: ⚫          │  │                  │                     │
+│  │ 소스: 버튼        │  │ LED: ⚫          │                     │
+│  └──────────────────┘  │ 소스: -           │                     │
+│                        └──────────────────┘                     │
+│                                                                 │
+│  ┌─ 시뮬레이션 모드 (하드웨어 미연결 시) ────────────────────────┐ │
+│  │ [환기 버튼]  [관수 버튼]  [조명 버튼]  [차광 버튼]            │ │
+│  │ ↑ 클릭하면 ESP8266 버튼 누름을 시뮬레이션                     │ │
+│  │   (POST /control/report → SSE → UI 반영)                    │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 컴포넌트 구조
+
+```
+ManualControlPanel (메인 컨테이너)
+├── ControlCard × 4 (환기/관수/조명/차광)
+│   ├── 제어 UI (슬라이더/토글)
+│   ├── LED 상태 인디케이터
+│   └── 소스 배지 (수동/버튼/AI)
+└── SimulationBar (시뮬레이션 모드 ON일 때 표시)
+    └── SimButton × 4 (ESP8266 버튼 시뮬레이션)
+```
+
+### 4.3 useManualControl 훅
+
+```typescript
+// frontend/src/hooks/useManualControl.ts
+
+const API_BASE = 'http://iot.lilpa.moe/api/v1';
+
+export function useManualControl() {
+  const [controlState, setControlState] = useState<ManualControlState | null>(null);
+  const [simMode, setSimMode] = useState(false);
+
+  // 초기 로드: GET /control/state
+  useEffect(() => {
+    fetchControlState();
+  }, []);
+
+  // 제어 명령 전송 (프론트엔드 → Relay)
+  const sendCommand = async (
+    controlType: ControlCommand['control_type'],
+    action: Record<string, unknown>
+  ) => { /* POST /api/v1/control */ };
+
+  // 시뮬레이션: ESP8266 버튼 누름 흉내
+  const simulateButton = async (
+    controlType: ControlCommand['control_type']
+  ) => { /* POST /api/v1/control/report (source: "button") */ };
+
+  // SSE control 이벤트로 상태 업데이트 (useSensorData에서 콜백)
+  const handleControlEvent = (event: ControlEvent) => {
+    setControlState(prev => /* merge event into state */);
+  };
+
+  return {
+    controlState,
+    simMode,
+    setSimMode,
+    sendCommand,
+    simulateButton,
+    handleControlEvent,
+  };
+}
+```
+
+### 4.4 useSensorData 확장
+
+```typescript
+// 기존 useSensorData.ts에 추가할 부분
+
+// SSE control 이벤트 리스너 추가
+es.addEventListener('control', (e) => {
+  const controlEvent = JSON.parse(e.data) as ControlEvent;
+  // 외부에서 전달받은 콜백으로 처리
+  onControlEvent?.(controlEvent);
+});
+```
+
+**변경 방식**: useSensorData의 반환값에 `onControlEvent` 콜백 등록 메커니즘 추가. 또는 별도 SSE 연결 대신, **useManualControl 안에서 동일한 SSE 스트림을 구독**하는 방식도 가능. (기존 EventSource 인스턴스를 공유하면 연결 1개로 유지)
+
+**선택: useSensorData 확장 방식** — 기존 SSE 연결을 재사용하여 연결 수 최소화.
+
+---
+
+## 5. Relay Server Design Detail
+
+### 5.1 control_store.py 상세
+
+```python
+# iot_relay_server/app/control_store.py
+
+import json
+import os
+from datetime import datetime, timezone
+from app.store import _broadcast
+
+CONTROL_STATE_FILE = "control_state.json"
+
+# 인메모리 상태
+control_state: dict = { ... }  # §2.1 참조
+pending_commands: dict = {}
+control_history: list[dict] = []
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def _save_state():
+    """파일로 영속화 — Docker 재시작 시 복원용"""
+    with open(CONTROL_STATE_FILE, "w") as f:
+        json.dump(control_state, f)
+
+def _load_state():
+    """서버 시작 시 마지막 상태 복원"""
+    if os.path.exists(CONTROL_STATE_FILE):
+        with open(CONTROL_STATE_FILE) as f:
+            saved = json.load(f)
+            control_state.update(saved)
+
+def update_control_state(control_type: str, values: dict, source: str):
+    """제어 상태 업데이트 + 이력 기록 + 파일 저장"""
+    state = control_state[control_type]
+    for key, val in values.items():
+        if key in state:
+            state[key] = val
+    state["source"] = source
+    state["updated_at"] = _now_iso()
+
+    # active 플래그 자동 설정
+    if control_type == "ventilation":
+        state["active"] = state.get("window_open_pct", 0) > 0 or state.get("fan_speed", 0) > 0
+        state["led_on"] = state["active"]
+    elif control_type == "irrigation":
+        state["active"] = state.get("valve_open", False)
+        state["led_on"] = state["active"]
+    elif control_type == "lighting":
+        state["active"] = state.get("on", False)
+        state["led_on"] = state["active"]
+    elif control_type == "shading":
+        state["active"] = state.get("shade_pct", 0) > 0 or state.get("insulation_pct", 0) > 0
+        state["led_on"] = state["active"]
+
+    # 이력 기록 (최근 100건)
+    control_history.append({
+        "control_type": control_type,
+        "state": dict(state),
+        "source": source,
+        "timestamp": _now_iso(),
+    })
+    if len(control_history) > 100:
+        control_history[:] = control_history[-100:]
+
+    _save_state()
+
+def add_pending_command(control_type: str, action: dict):
+    """ESP8266이 폴링으로 가져갈 명령 추가 (최신 상태 덮어쓰기)"""
+    pending_commands[control_type] = {
+        **action,
+        "timestamp": _now_iso(),
+    }
+
+def get_and_clear_pending(device_id: str) -> dict:
+    """ESP8266이 명령을 가져가면 큐 클리어"""
+    if not pending_commands:
+        return {}
+    commands = dict(pending_commands)
+    return commands
+
+def clear_acknowledged(control_types: list[str]):
+    """ACK 받은 명령만 큐에서 제거"""
+    for ct in control_types:
+        pending_commands.pop(ct, None)
+
+def get_control_state() -> dict:
+    return dict(control_state)
+```
+
+### 5.2 control_routes.py 상세
+
+```python
+# iot_relay_server/app/control_routes.py
+
+from fastapi import APIRouter, Depends, Query
+from app.main import verify_api_key  # 기존 API Key 검증 재사용
+from app.schemas import ControlCommandIn, ControlReportIn, ControlAckIn
+from app.store import _broadcast
+from app.control_store import (
+    update_control_state,
+    add_pending_command,
+    get_and_clear_pending,
+    clear_acknowledged,
+    get_control_state,
+    control_state,
+    _now_iso,
+)
+
+control_router = APIRouter(prefix="/api/v1/control", tags=["control"])
+
+@control_router.post("")
+async def send_control(data: ControlCommandIn):
+    update_control_state(data.control_type, data.action, data.source)
+    add_pending_command(data.control_type, data.action)
+    _broadcast("control", {
+        "control_type": data.control_type,
+        "state": control_state[data.control_type],
+        "source": data.source,
+        "timestamp": _now_iso(),
+    })
+    return {"status": "ok", "state": control_state[data.control_type]}
+
+@control_router.get("/state")
+async def get_state():
+    return get_control_state()
+
+@control_router.get("/commands", dependencies=[Depends(verify_api_key)])
+async def get_commands(device_id: str = Query(...)):
+    commands = get_and_clear_pending(device_id)
+    return {"commands": commands, "timestamp": _now_iso()}
+
+@control_router.post("/report", dependencies=[Depends(verify_api_key)])
+async def report_state(data: ControlReportIn):
+    update_control_state(data.control_type, data.state, data.source)
+    _broadcast("control", {
+        "control_type": data.control_type,
+        "state": control_state[data.control_type],
+        "source": data.source,
+        "timestamp": _now_iso(),
+    })
+    return {"status": "ok"}
+
+@control_router.post("/ack", dependencies=[Depends(verify_api_key)])
+async def ack_commands(data: ControlAckIn):
+    clear_acknowledged(data.acknowledged_types)
+    return {"status": "ok"}
+```
+
+### 5.3 main.py 수정
+
+```python
+# iot_relay_server/app/main.py 에 추가
+
+from app.control_routes import control_router
+from app.control_store import _load_state
+
+# 서버 시작 시 제어 상태 복원
+@app.on_event("startup")
+async def startup():
+    _load_state()
+
+# 라우터 등록 (기존 라우터들 다음에)
+app.include_router(control_router)
+```
+
+---
+
+## 6. ESP8266 Firmware Design
+
+### 6.1 현재 상태 vs 변경 계획
+
+| 항목 | 현재 | 변경 후 |
+|------|------|---------|
+| **센서 루프** | 30초 간격 POST /sensors | 유지 (변경 없음) |
+| **폴링 루프** | 없음 | 2~3초 간격 GET /control/commands |
+| **버튼 처리** | 없음 | 인터럽트 + 디바운싱 → POST /control/report |
+| **LED 출력** | 없음 | 명령 수신 또는 버튼 누름 시 LED ON/OFF |
+| **핀 사용** | D4(DHT11), A0(LDR) | + D1~D8 중 버튼/LED용 (Phase별) |
+
+### 6.2 펌웨어 구조 변경
+
+```cpp
+// DH11_KY018_WiFi.ino — 변경 후 구조
+
+// === 기존 (유지) ===
+#define DHT_PIN D4
+#define LDR_PIN A0
+unsigned long lastSensorPost = 0;
+const unsigned long SENSOR_INTERVAL = 30000;  // 30초
+
+// === 신규 (추가) ===
+// Phase 1: 환기 LED/버튼
+#define VENT_LED_PIN D1
+#define VENT_BTN_PIN D2
+// Phase 2~4는 해당 Phase 구현 시 주석 해제
+// #define IRR_LED_PIN D5
+// #define IRR_BTN_PIN D6
+// #define LIGHT_LED_PIN D7
+// #define LIGHT_BTN_PIN D8
+// #define SHADE_LED_PIN D3
+// #define SHADE_BTN_PIN D0
+
+unsigned long lastControlPoll = 0;
+const unsigned long CONTROL_POLL_INTERVAL = 3000;  // 3초
+
+// 버튼 디바운싱
+volatile bool ventButtonPressed = false;
+unsigned long lastVentButtonTime = 0;
+#define DEBOUNCE_MS 200
+
+// LED 상태
+bool ventLedState = false;
+
+void setup() {
+  // 기존 센서 초기화 유지
+  // ...
+
+  // 버튼/LED 초기화 (Phase 1)
+  pinMode(VENT_LED_PIN, OUTPUT);
+  pinMode(VENT_BTN_PIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(VENT_BTN_PIN), ventButtonISR, FALLING);
+}
+
+void loop() {
+  unsigned long now = millis();
+
+  // 1. 기존 센서 전송 (30초)
+  if (now - lastSensorPost >= SENSOR_INTERVAL) {
+    postSensorData();
+    lastSensorPost = now;
+  }
+
+  // 2. 제어 명령 폴링 (3초)
+  if (now - lastControlPoll >= CONTROL_POLL_INTERVAL) {
+    pollControlCommands();
+    lastControlPoll = now;
+  }
+
+  // 3. 버튼 이벤트 처리 (인터럽트 플래그 확인)
+  if (ventButtonPressed) {
+    ventButtonPressed = false;
+    handleVentButton();
+  }
+}
+
+// 버튼 인터럽트 핸들러
+ICACHE_RAM_ATTR void ventButtonISR() {
+  if (millis() - lastVentButtonTime > DEBOUNCE_MS) {
+    ventButtonPressed = true;
+    lastVentButtonTime = millis();
+  }
+}
+
+// 제어 명령 폴링
+void pollControlCommands() {
+  // GET /api/v1/control/commands?device_id=esp8266-01
+  // 명령 있으면 LED 상태 변경 + POST /control/ack
+}
+
+// 버튼 눌림 처리
+void handleVentButton() {
+  ventLedState = !ventLedState;
+  digitalWrite(VENT_LED_PIN, ventLedState ? HIGH : LOW);
+  // POST /api/v1/control/report
+}
+```
+
+### 6.3 하드웨어 미구성 대응 (현재 상태)
+
+ESP8266 펌웨어에서 하드웨어가 없는 동안의 처리:
+
+```cpp
+// 컴파일 플래그로 하드웨어 활성화 제어
+#define HARDWARE_BUTTONS_ENABLED false  // 회로 구성 후 true로 변경
+
+void setup() {
+  // 기존 센서 초기화...
+
+  #if HARDWARE_BUTTONS_ENABLED
+    pinMode(VENT_LED_PIN, OUTPUT);
+    pinMode(VENT_BTN_PIN, INPUT_PULLUP);
+    attachInterrupt(digitalPinToInterrupt(VENT_BTN_PIN), ventButtonISR, FALLING);
+  #endif
+}
+
+void loop() {
+  // 센서 전송은 항상 동작
+  // 폴링 루프도 항상 동작 (하드웨어 없어도 명령 수신/ACK 가능)
+  // 버튼/LED는 HARDWARE_BUTTONS_ENABLED일 때만
+
+  #if HARDWARE_BUTTONS_ENABLED
+    if (ventButtonPressed) { ... }
+  #endif
+}
+```
+
+---
+
+## 7. Communication Flow
+
+### 7.1 Flow A: 프론트엔드 → ESP8266 (원격 제어)
+
+```
+사용자 (브라우저)
+    │ 환기 슬라이더 70%로 조작
+    v
+ManualControlPanel
+    │ sendCommand("ventilation", {window_open_pct: 70})
+    v
+useManualControl
+    │ POST /api/v1/control
+    v
+Relay Server (control_routes.py)
+    ├─ update_control_state() → 인메모리 업데이트
+    ├─ add_pending_command()  → ESP8266용 큐에 추가
+    └─ _broadcast("control") → SSE 이벤트 전송
+          │
+          ├──→ Frontend (SSE) → UI 즉시 반영 (낙관적 업데이트)
+          │
+          └──→ (대기)
+                    │
+ESP8266 (2~3초 후 폴링)
+    │ GET /api/v1/control/commands
+    v
+    명령 수신 → LED ON + POST /control/ack
+```
+
+**응답 시간**: UI 즉시 반영 + ESP8266 LED 반응 최대 ~5초 (폴링 주기)
+
+### 7.2 Flow B: ESP8266 → 프론트엔드 (버튼 제어)
+
+```
+사용자 (현장)
+    │ 환기 버튼 누름
+    v
+ESP8266
+    │ 인터럽트 → LED 토글 → POST /api/v1/control/report
+    v
+Relay Server (control_routes.py)
+    ├─ update_control_state() → 인메모리 업데이트
+    └─ _broadcast("control") → SSE 이벤트 전송
+          │
+          v
+Frontend (SSE)
+    │ control 이벤트 수신
+    v
+useManualControl.handleControlEvent()
+    │ controlState 업데이트
+    v
+ManualControlPanel → UI 즉시 반영
+```
+
+**응답 시간**: ~1~2초 (네트워크 왕복 + SSE 전달)
+
+### 7.3 Flow C: 시뮬레이션 모드 (하드웨어 없이 테스트)
+
+```
+사용자 (브라우저, 시뮬레이션 모드 ON)
+    │ [환기 버튼 시뮬레이션] 클릭
+    v
+ManualControlPanel
+    │ simulateButton("ventilation")
+    v
+useManualControl
+    │ POST /api/v1/control/report  ← ESP8266 대신 프론트엔드가 직접 호출
+    │ { device_id: "simulator", control_type: "ventilation",
+    │   state: { led_on: true, active: true }, source: "button" }
+    v
+Relay Server
+    ├─ update_control_state()
+    └─ _broadcast("control") → SSE
+          │
+          v
+Frontend → UI 반영 (양방향 흐름 전체 테스트 완료)
+```
+
+---
+
+## 8. Test Plan
+
+### 8.1 하드웨어 미구성 단계 테스트 (현재)
+
+| # | 테스트 | 방법 | 기대 결과 |
+|---|--------|------|-----------|
+| T0-1 | Relay API 동작 | curl POST /control | 200 + state 반환 |
+| T0-2 | SSE control 이벤트 | curl -N /sensors/stream + 별도 터미널에서 POST /control | SSE에 control 이벤트 수신 |
+| T0-3 | 프론트엔드 UI 렌더링 | 브라우저에서 IoT 대시보드 | ManualControlPanel 표시 |
+| T0-4 | 프론트엔드 → SSE 반영 | UI에서 환기 토글 | 슬라이더 값 즉시 반영 |
+| T0-5 | 시뮬레이션 모드 | 시뮬레이션 ON → 환기 버튼 클릭 | LED 상태 + 소스 "버튼"으로 변경 |
+| T0-6 | 상태 영속화 | Relay Server 재시작 후 GET /control/state | 마지막 상태 복원 |
+
+### 8.2 Phase별 하드웨어 테스트 (회로 구성 후)
+
+| Phase | 테스트 | 성공 기준 |
+|-------|--------|-----------|
+| 1 | 프론트엔드 환기 ON → ESP8266 LED 점등 | 5초 이내 |
+| 1 | ESP8266 환기 버튼 → 프론트엔드 반영 | 2초 이내 |
+| 2 | 프론트엔드 밸브 열림 → ESP8266 관수 LED | 5초 이내 |
+| 2 | ESP8266 관수 버튼 → 프론트엔드 반영 | 2초 이내 |
+| 3 | 프론트엔드 조명 ON → ESP8266 조명 LED | 5초 이내 |
+| 4 | 4개 제어 동시 조작 → 상태 정합성 | 모든 상태 일치 |
+
+### 8.3 curl 테스트 커맨드
+
+```bash
+# 1. 프론트엔드 제어 시뮬레이션
+curl -X POST http://iot.lilpa.moe:9000/api/v1/control \
+  -H "Content-Type: application/json" \
+  -d '{"control_type":"ventilation","action":{"active":true,"window_open_pct":70},"source":"manual"}'
+
+# 2. 상태 조회
+curl http://iot.lilpa.moe:9000/api/v1/control/state
+
+# 3. ESP8266 폴링 시뮬레이션
+curl -H "X-API-Key: farmos-iot-default-key" \
+  "http://iot.lilpa.moe:9000/api/v1/control/commands?device_id=esp8266-01"
+
+# 4. ESP8266 버튼 보고 시뮬레이션
+curl -X POST http://iot.lilpa.moe:9000/api/v1/control/report \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: farmos-iot-default-key" \
+  -d '{"device_id":"esp8266-01","control_type":"ventilation","state":{"led_on":true,"active":true,"window_open_pct":100},"source":"button"}'
+
+# 5. SSE 스트림 모니터링 (별도 터미널)
+curl -N http://iot.lilpa.moe:9000/api/v1/sensors/stream
+```
+
+---
+
+## 9. Phase별 구현 순서
+
+### Phase 1: 환기 (전체 인프라 구축)
+
+**순서 (Software-First):**
+
+1. Relay Server: `control_store.py` 생성 (인메모리 상태 + 파일 영속화)
+2. Relay Server: `schemas.py`에 제어 스키마 추가
+3. Relay Server: `control_routes.py` 생성 (5개 API)
+4. Relay Server: `main.py`에 라우터 등록 + startup 이벤트
+5. **→ N100 업로드 + Docker 재시작 (사용자 작업)**
+6. curl로 API 테스트 (T0-1, T0-2)
+7. Frontend: `types/index.ts`에 타입 추가
+8. Frontend: `useManualControl.ts` 훅 생성
+9. Frontend: `useSensorData.ts` SSE control 이벤트 추가
+10. Frontend: `ManualControlPanel.tsx` 생성 (환기만 활성, 시뮬레이션 모드 포함)
+11. Frontend: `IoTDashboardPage.tsx`에 ManualControlPanel 임포트
+12. 브라우저에서 시뮬레이션 모드 테스트 (T0-3 ~ T0-5)
+13. ESP8266: 폴링 루프 추가 (HARDWARE_BUTTONS_ENABLED=false)
+14. **→ 회로 구성 후: 버튼/LED 배선 + HARDWARE_BUTTONS_ENABLED=true**
+15. 실물 양방향 테스트
+
+### Phase 2~4: 관수 → 조명 → 차광
+
+각 Phase에서 추가 작업:
+- `ManualControlPanel`에 해당 제어 카드 활성화
+- ESP8266에 해당 버튼/LED 핀 define + ISR 추가
+- Relay Server 변경 없음 (이미 4개 제어 타입 모두 지원)
+
+---
+
+## 10. Deployment Notes
+
+### 10.1 변경 대상별 배포 절차
+
+| 대상 | 변경 파일 | 배포 방식 | 비고 |
+|------|-----------|-----------|------|
+| **Relay Server** | control_store.py, control_routes.py, schemas.py, main.py | N100에 업로드 → Docker 재빌드 | **사용자 직접 수행** |
+| **Frontend** | ManualControlPanel.tsx, useManualControl.ts, useSensorData.ts, types/index.ts, IoTDashboardPage.tsx | 로컬 `npm run dev` 자동 반영 | 핫 리로드 |
+| **ESP8266** | DH11_KY018_WiFi.ino | Arduino IDE → 시리얼 업로드 | **사용자 직접 수행** |
+
+### 10.2 Relay Server 배포 명령
+
+```bash
+# N100 서버에서 실행
+cd iot_relay_server
+docker compose down
+docker compose up -d --build
+
+# 헬스체크
+curl http://iot.lilpa.moe:9000/health
+
+# 제어 API 확인
+curl http://iot.lilpa.moe:9000/api/v1/control/state
+```
+
+> **서버 직접 조작 금지** — 코드 수정 후 사용자에게 위 절차 안내
+
+---
+
+## 11. Implementation Guide
+
+### 11.1 Module Map
+
+| Module | 범위 | 파일 수 | 의존성 |
+|--------|------|---------|--------|
+| **module-1** | Relay Server 제어 API | 4 (control_store.py, control_routes.py, schemas.py 수정, main.py 수정) | 없음 (독립) |
+| **module-2** | Frontend 훅 + 타입 | 3 (useManualControl.ts, useSensorData.ts 수정, types/index.ts 수정) | module-1 완료 필요 |
+| **module-3** | Frontend UI 컴포넌트 | 2 (ManualControlPanel.tsx, IoTDashboardPage.tsx 수정) | module-2 완료 필요 |
+| **module-4** | ESP8266 펌웨어 | 1 (DH11_KY018_WiFi.ino 수정) | module-1 완료 필요 |
+
+### 11.2 Recommended Session Plan
+
+| Session | Module | 예상 작업 | 배포 필요 |
+|---------|--------|-----------|-----------|
+| **Session 1** | module-1 | Relay Server 코드 작성 → N100 배포 요청 → curl 테스트 | Relay Server (N100) |
+| **Session 2** | module-2 + module-3 | Frontend 훅/타입/UI 구현 → 시뮬레이션 모드 테스트 | 없음 (로컬 핫 리로드) |
+| **Session 3** | module-4 | ESP8266 펌웨어 수정 → 하드웨어 배선 → 실물 테스트 | ESP8266 (시리얼 업로드) |
+
+### 11.3 Session Guide
+
+```
+/pdca do iot-manual-control --scope module-1        # Relay Server API
+/pdca do iot-manual-control --scope module-2,module-3  # Frontend 전체
+/pdca do iot-manual-control --scope module-4        # ESP8266 펌웨어
+```
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-04-16 | Initial draft — Option C (Pragmatic Balance) | clover0309 |

--- a/docs/03-analysis/iot-manual-control.analysis.md
+++ b/docs/03-analysis/iot-manual-control.analysis.md
@@ -1,0 +1,134 @@
+# IoT Manual Control — Gap Analysis Report
+
+> **Feature**: iot-manual-control
+> **Date**: 2026-04-16
+> **Design**: `docs/02-design/features/iot-manual-control.design.md`
+
+---
+
+## Context Anchor
+
+| Key | Value |
+|-----|-------|
+| **WHY** | 센서 모니터링만 가능한 IoT 시스템에 양방향 수동 제어 추가 |
+| **WHO** | FarmOS 사용자 (1인 농업인) |
+| **RISK** | ESP8266 HTTP-only, 폴링 지연, N100 재배포 필요 |
+| **SUCCESS** | 프론트엔드 토글 → 5초 내 ESP8266 반응, ESP8266 → 2초 내 프론트엔드 반영 |
+| **SCOPE** | module-1~3 구현 완료, module-4(ESP8266) 하드웨어 구성 후 진행 |
+
+---
+
+## Overall Scores
+
+| Category | Score | Status |
+|----------|:-----:|:------:|
+| Structural Match | 100% | PASS |
+| Functional Depth | 95% | PASS |
+| API Contract | 100% | PASS |
+| L1 Runtime (API) | 100% (9/9) | PASS |
+| **Overall** | **98%** | **PASS** |
+
+Formula: (Structural x 0.2) + (Functional x 0.4) + (Contract x 0.4) = 20 + 38 + 40 = **98%**
+
+---
+
+## Structural Match (100%)
+
+| # | Design File | Status | Path |
+|---|-------------|:------:|------|
+| 1 | control_store.py [NEW] | PASS | iot_relay_server/app/ |
+| 2 | control_routes.py [NEW] | PASS | iot_relay_server/app/ |
+| 3 | schemas.py [MODIFY] | PASS | iot_relay_server/app/ |
+| 4 | main.py [MODIFY] | PASS | iot_relay_server/app/ |
+| 5 | ai_agent.py [MODIFY] | PASS | iot_relay_server/app/ |
+| 6 | tools/executor.py [MODIFY] | PASS | iot_relay_server/app/ |
+| 7 | useManualControl.ts [NEW] | PASS | frontend/src/hooks/ |
+| 8 | useSensorData.ts [MODIFY] | PASS | frontend/src/hooks/ |
+| 9 | useAIAgent.ts [MODIFY] | ENHANCED | frontend/src/hooks/ (Design: 유지, 실제: SSE 추가) |
+| 10 | ManualControlPanel.tsx [NEW] | PASS | frontend/src/modules/iot/ |
+| 11 | IoTDashboardPage.tsx [MODIFY] | PASS | frontend/src/modules/iot/ |
+| 12 | types/index.ts [MODIFY] | PASS | frontend/src/types/ |
+
+---
+
+## API Contract (100%)
+
+| # | Endpoint | Auth | Status |
+|---|----------|:----:|:------:|
+| 1 | POST /api/v1/control | - | PASS |
+| 2 | GET /api/v1/control/state | - | PASS |
+| 3 | GET /api/v1/control/commands | X-API-Key | PASS |
+| 4 | POST /api/v1/control/report | X-API-Key | PASS |
+| 5 | POST /api/v1/control/ack | X-API-Key | PASS |
+| 6 | POST /api/v1/control/unlock | - | PASS (Design 초과) |
+
+---
+
+## L1 Runtime Test Results (9/9 PASS)
+
+| # | Test | Expected | Result |
+|---|------|----------|:------:|
+| T1 | POST /control → state 반환 | 200 + locked=true | PASS |
+| T2 | GET /control/state | 200 | PASS |
+| T3 | GET /commands without auth | 403 | PASS |
+| T4 | GET /commands with auth | 200 | PASS |
+| T5 | POST /report without auth | 403 | PASS |
+| T6 | POST /report with auth | 200 | PASS |
+| T7 | POST /ack with auth | 200 | PASS |
+| T8 | POST /unlock → locked=false | 200 | PASS |
+| T9 | Invalid control_type | 422 | PASS |
+
+---
+
+## Success Criteria Evaluation
+
+| Criteria | Status | Evidence |
+|----------|:------:|---------|
+| 4개 제어 UI 동작 | PASS | ManualControlPanel에 환기/관수/조명/차광 카드 |
+| 시뮬레이션 모드 | PASS | simulateButton() → /control/report (device_id: simulator) |
+| SSE 실시간 반영 | PASS | useSensorData SSE control 이벤트 → handleControlEvent |
+| 제어 상태 영속화 | PASS | control_state.json 파일 저장/복원 |
+| AI Agent 통합 | PASS | control_store가 Single Source of Truth |
+| 수동 잠금(locked) | PASS | 수동 제어 시 자동 잠금, 자물쇠 클릭으로 해제 |
+| module-4 (ESP8266) | PENDING | 하드웨어 미구성 — 시뮬레이션으로 대체 검증 |
+
+---
+
+## Design 초과 구현 (15건)
+
+| # | 항목 | 설명 |
+|---|------|------|
+| 1 | locked 필드 | 수동 잠금/해제 기능 |
+| 2 | POST /control/unlock | 잠금 해제 엔드포인트 |
+| 3 | ControlSlider 컴포넌트 | 드래그 중 로컬 state |
+| 4 | sendCommandImmediate | 버튼용 즉시 실행 |
+| 5 | SSE ai_decision 리스너 | AI 판단 즉시 반영 |
+| 6 | 5초 AI SSE 가드 | 슬라이더 snap-back 방지 |
+| 7 | get_control_state_for_ai() | AI용 정제된 상태 |
+| 8 | reset_daily_irrigation() | 일일 관수량 리셋 |
+| 9 | 관수 추가 필드 | daily_total_L, last_watered, nutrient |
+| 10 | 낙관적 업데이트 | API 응답 전 UI 즉시 반영 |
+| 11 | API_BASE https | Cloudflare CORS 대응 |
+| 12 | LockButton 컴포넌트 | 자물쇠 UI |
+| 13 | onAIDecisionEvent | AI 판단 콜백 |
+| 14 | credentials: 'omit' | CORS 호환성 |
+| 15 | 팬 속도 버튼 UI | 슬라이더 대신 이산 값 버튼 |
+
+---
+
+## Minor Deductions (2건)
+
+| # | 항목 | Severity | 설명 |
+|---|------|:--------:|------|
+| 1 | 팬 속도 UI | Minor | Design 와이어프레임은 슬라이더 암시, 구현은 이산 버튼 (UX 개선) |
+| 2 | useAIAgent.ts 변경 | Minor | Design에서 [유지]로 표기, 실제로 SSE 통합 수정 (문서 갱신 필요) |
+
+**Critical/Important 이슈: 없음**
+
+---
+
+## Recommended Actions
+
+1. Design 문서에 locked/unlock 기능 반영 (문서 갱신)
+2. module-4 (ESP8266 펌웨어) 하드웨어 구성 후 구현
+3. 시뮬레이션 모드의 API Key 노출은 개발 환경 trade-off로 수용

--- a/docs/04-report/iot-manual-control.report.md
+++ b/docs/04-report/iot-manual-control.report.md
@@ -1,0 +1,206 @@
+# IoT Manual Control — Completion Report
+
+> **Feature**: iot-manual-control
+> **Date**: 2026-04-16
+> **Match Rate**: 98%
+> **Status**: Completed (module-1~3), module-4 Pending (하드웨어)
+
+---
+
+## 1. Executive Summary
+
+### 1.1 Feature Overview
+
+| Perspective | Planned | Delivered |
+|-------------|---------|-----------|
+| **Problem** | IoT 시스템이 센서 모니터링만 가능, 수동 제어 및 하드웨어 양방향 연동 부재 | Relay Server 제어 API 6개 + Frontend 수동 제어 UI + AI Agent 통합 완료 |
+| **Solution** | 프론트엔드 4대 제어 UI + ESP8266 버튼/LED + Relay Server 중계 | control_store(Single Source of Truth) + ManualControlPanel + 시뮬레이션 모드 |
+| **Function/UX** | 슬라이더/토글로 제어, LED 양방향 동기화, 시뮬레이션 모드 | 낙관적 업데이트 + ControlSlider + sendCommandImmediate + 자물쇠 잠금/해제 |
+| **Core Value** | PC 대시보드 또는 현장 버튼으로 즉시 제어 가능한 통합 경험 | AI/수동/버튼 3개 소스가 하나의 파이프라인 공유, 수동 잠금으로 AI 오버라이드 방지 |
+
+### 1.2 Value Delivered
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| Match Rate | >= 90% | **98%** |
+| API Endpoints | 5개 | **6개** (unlock 추가) |
+| L1 Runtime Tests | Pass | **9/9 PASS** |
+| Module 완료 | 4/4 | **3/4** (module-4 하드웨어 대기) |
+| Critical Issues | 0 | **0** |
+
+---
+
+## 2. PDCA Cycle Summary
+
+| Phase | Date | Output | Status |
+|-------|------|--------|:------:|
+| Plan | 2026-04-16 | `docs/01-plan/features/iot-manual-control.plan.md` | Done |
+| Design | 2026-04-16 | `docs/02-design/features/iot-manual-control.design.md` | Done |
+| Do (module-1) | 2026-04-16 | Relay Server API + AI Agent 통합 | Done + Deployed |
+| Do (module-2,3) | 2026-04-16 | Frontend 훅 + UI | Done |
+| Do (module-4) | - | ESP8266 펌웨어 | Pending |
+| Check | 2026-04-16 | `docs/03-analysis/iot-manual-control.analysis.md` | 98% |
+| Report | 2026-04-16 | 이 문서 | Done |
+
+---
+
+## 3. Key Decisions & Outcomes
+
+| # | Decision | Source | Followed | Outcome |
+|---|----------|--------|:--------:|---------|
+| 1 | ESP8266 양방향 통신: 폴링 방식 | Plan | Yes | ESP8266 메모리 안정성 확보, 2~3초 폴링 주기 설계 |
+| 2 | 제어 상태: 인메모리 + 파일 백업 | Plan | Yes | control_state.json으로 Docker 재시작 시 복원 |
+| 3 | Option C: Pragmatic Balance | Design | Yes | 신규 4파일 + 수정 7파일로 적정 규모 |
+| 4 | AI Agent 통합 (Single Source of Truth) | Do 중 결정 | Yes | ai_agent.py 30곳 리팩토링, 3소스(AI/수동/버튼) 통합 |
+| 5 | 수동 잠금(locked) 기능 | Do 중 결정 | Yes | AI 일반규칙 오버라이드 방지, 자물쇠 UI |
+| 6 | API_BASE https (Cloudflare CORS) | Do 중 발견 | Yes | HTTP→HTTPS redirect로 preflight 실패 해결 |
+| 7 | ControlSlider (드래그 중 로컬 state) | Do 중 결정 | Yes | 슬라이더 snap-back 문제 해결 |
+| 8 | sendCommand/sendCommandImmediate 분리 | Do 중 결정 | Yes | 슬라이더(디바운스) vs 버튼(즉시) 분리 |
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Relay Server (iot_relay_server/app/)
+
+| File | Type | Lines | Description |
+|------|------|:-----:|-------------|
+| control_store.py | NEW | ~180 | 인메모리 상태 + locked + 명령 큐 + 파일 영속화 |
+| control_routes.py | NEW | ~60 | 6개 API 엔드포인트 |
+| schemas.py | MOD | +25 | 4개 Pydantic 스키마 |
+| main.py | MOD | +8 | 라우터 등록 + startup |
+| ai_agent.py | MOD | ~60 | control_store 통합, is_manual_override_active |
+| tools/executor.py | MOD | ~40 | 4개 제어 핸들러 control_store 경유 |
+
+### 4.2 Frontend (FarmOS/frontend/src/)
+
+| File | Type | Lines | Description |
+|------|------|:-----:|-------------|
+| hooks/useManualControl.ts | NEW | ~150 | sendCommand + sendCommandImmediate + simulate + unlock |
+| modules/iot/ManualControlPanel.tsx | NEW | ~380 | 4개 제어 카드 + ControlSlider + LockButton + SimulationBar |
+| hooks/useSensorData.ts | MOD | +20 | SSE control + ai_decision 콜백 |
+| hooks/useAIAgent.ts | MOD | +30 | SSE ai_decision 즉시 반영, decisions fetch |
+| modules/iot/IoTDashboardPage.tsx | MOD | +2 | ManualControlPanel 임포트 |
+| types/index.ts | MOD | +50 | ManualControlState 등 7개 타입 |
+| modules/iot/AIAgentPanel.tsx | MOD | +15 | decisions 여러 건 표시 |
+
+---
+
+## 5. Success Criteria Final Status
+
+| # | Criteria | Status | Evidence |
+|---|----------|:------:|---------|
+| SC-1 | 프론트엔드 4개 제어 UI 동작 | Met | ManualControlPanel: 환기/관수/조명/차광 카드 |
+| SC-2 | ESP8266 버튼 → LED → 프론트엔드 반영 | Partial | 시뮬레이션 모드로 검증 완료, 실 하드웨어 미테스트 |
+| SC-3 | 프론트엔드 → ESP8266 LED 반응 | Partial | API 경로 검증 완료, 실 하드웨어 미테스트 |
+| SC-4 | 양방향 동기화 | Met | SSE control 이벤트로 즉시 반영 |
+| SC-5 | 제어 상태 영속화 | Met | control_state.json 저장/복원 |
+| SC-6 | AI Agent 통합 | Met | control_store Single Source of Truth |
+| SC-7 | 수동 잠금/해제 | Met | locked 필드 + 자물쇠 UI |
+
+**Overall: 5/7 Met, 2/7 Partial** (하드웨어 의존 항목)
+
+---
+
+## 6. Design-Beyond Implementations (15건)
+
+구현 과정에서 Design 문서에 없지만 추가된 개선사항:
+
+1. **locked 필드** — 수동 잠금/해제 (AI 오버라이드 방지)
+2. **POST /control/unlock** — 잠금 해제 API
+3. **ControlSlider** — 드래그 중 로컬 state, 놓으면 서버 전송
+4. **sendCommandImmediate** — 버튼용 즉시 실행 (디바운스 없음)
+5. **SSE ai_decision 리스너** — AI 판단 즉시 UI 반영
+6. **5초 AI SSE 가드** — 수동 조작 직후 AI SSE 무시
+7. **get_control_state_for_ai()** — AI용 정제 상태
+8. **reset_daily_irrigation()** — 일일 관수량 리셋
+9. **관수 추가 필드** — daily_total_L, last_watered, nutrient
+10. **낙관적 업데이트** — API 응답 전 UI 즉시 반영
+11. **API_BASE https** — Cloudflare CORS 해결
+12. **LockButton 컴포넌트** — 자물쇠 UI
+13. **onAIDecisionEvent** — AI 판단 콜백 시스템
+14. **credentials: 'omit'** — CORS 호환성
+15. **팬 속도 이산 버튼** — 슬라이더 대신 0/500/1000/1500/3000 RPM
+
+---
+
+## 7. Issues Encountered & Resolved
+
+| # | Issue | Root Cause | Resolution |
+|---|-------|-----------|------------|
+| 1 | AI Agent 판단 이력 1건만 표시 | `latest_decision` 1건만 반환, decisions API 미사용 | useAIAgent에 `/decisions` fetch 추가 |
+| 2 | 슬라이더 값이 0%로 복귀 | AI 규칙이 수동 제어를 덮어씀 + SSE echo | locked 필드 + ControlSlider (로컬 drag state) |
+| 3 | CORS preflight 실패 | Cloudflare HTTP→HTTPS redirect | API_BASE를 https로 변경 |
+| 4 | 관수/조명 자물쇠 미작동 | sendCommand 디바운스 300ms로 POST 지연 | sendCommandImmediate (즉시 실행) 분리 |
+| 5 | AI Agent 반응 느림 | 30초 폴링 의존 | SSE ai_decision 이벤트로 즉시 반영 |
+
+---
+
+## 8. Remaining Work
+
+| Item | Priority | Description |
+|------|:--------:|-------------|
+| module-4: ESP8266 펌웨어 | High | 버튼/LED 회로 구성 후 폴링 루프 + ISR 구현 |
+| Design 문서 갱신 | Low | locked/unlock, ControlSlider 등 15건 반영 |
+| 시뮬레이션 API Key 노출 | Low | 개발 환경 trade-off로 수용 |
+
+---
+
+## 9. Architecture Diagram (Final)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Frontend (React, localhost:5173)                              │
+│                                                              │
+│   ManualControlPanel ──→ useManualControl                    │
+│     ├─ ControlSlider (드래그: 로컬, 놓으면: sendCommand)      │
+│     ├─ 밸브/ON-OFF 버튼 → sendCommandImmediate               │
+│     ├─ LockButton → unlockControl                            │
+│     └─ SimulationBar → simulateButton                        │
+│                                                              │
+│   useSensorData ──→ SSE(control, ai_decision) ──→ callbacks  │
+│   useAIAgent ──→ SSE ai_decision + 60s polling fallback      │
+│                                                              │
+│   API_BASE: https://iot.lilpa.moe (Cloudflare TLS 종료)      │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ HTTPS
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│ Cloudflare (TLS Termination)                                 │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ HTTP
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│ IoT Relay Server (N100, Docker, FastAPI)                      │
+│                                                              │
+│   control_routes.py ──→ control_store.py (Single Source)     │
+│     POST /control         update_control_state()             │
+│     GET  /control/state   get_control_state()                │
+│     GET  /control/commands get_and_clear_pending()            │
+│     POST /control/report  update_control_state(button)       │
+│     POST /control/ack     clear_acknowledged()               │
+│     POST /control/unlock  unlock_control()                   │
+│                                                              │
+│   ai_agent.py ──→ control_store (읽기/쓰기)                  │
+│     규칙 엔진 → is_manual_override_active() 체크 후 실행      │
+│     긴급 규칙 → locked 무시                                   │
+│                                                              │
+│   store.py → SSE _broadcast("control", "ai_decision")        │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ HTTP (:9000 직접)
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│ ESP8266 (module-4, 미구현)                                    │
+│   GET  /control/commands (2~3초 폴링)                        │
+│   POST /control/report (버튼 누름 시)                        │
+│   POST /control/ack (명령 수신 확인)                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-16 | Initial report — module-1~3 완료, 98% match rate |

--- a/frontend/src/hooks/useAIAgent.ts
+++ b/frontend/src/hooks/useAIAgent.ts
@@ -1,19 +1,28 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { AIAgentStatus, CropProfile } from '@/types';
+import type { AIAgentStatus, AIDecision, CropProfile } from '@/types';
+import { onAIDecisionEvent } from '@/hooks/useSensorData';
 
-const API_BASE = 'http://iot.lilpa.moe/api/v1';
-const POLL_INTERVAL = 30000;
+const API_BASE = 'https://iot.lilpa.moe/api/v1';
+const POLL_INTERVAL = 60000; // SSE가 실시간 처리하므로 폴링은 60초 fallback
 
 export function useAIAgent() {
   const [status, setStatus] = useState<AIAgentStatus | null>(null);
+  const [decisions, setDecisions] = useState<AIDecision[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}/ai-agent/status`, { credentials: 'omit' });
-      if (res.ok) {
-        const data = await res.json();
+      const [statusRes, decisionsRes] = await Promise.all([
+        fetch(`${API_BASE}/ai-agent/status`, { credentials: 'omit' }),
+        fetch(`${API_BASE}/ai-agent/decisions?limit=20`, { credentials: 'omit' }),
+      ]);
+      if (statusRes.ok) {
+        const data = await statusRes.json();
         setStatus(data);
+      }
+      if (decisionsRes.ok) {
+        const data = await decisionsRes.json();
+        setDecisions(data);
       }
     } catch {
       // 무시
@@ -27,6 +36,42 @@ export function useAIAgent() {
     const timer = setInterval(fetchStatus, POLL_INTERVAL);
     return () => clearInterval(timer);
   }, [fetchStatus]);
+
+  // SSE ai_decision 이벤트 → 판단 즉시 반영
+  useEffect(() => {
+    return onAIDecisionEvent((data) => {
+      const decision = data as AIDecision;
+
+      // decisions 목록 맨 앞에 추가
+      setDecisions(prev => [decision, ...prev].slice(0, 20));
+
+      // status의 latest_decision + total_decisions 업데이트
+      setStatus(prev => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          latest_decision: decision,
+          total_decisions: prev.total_decisions + 1,
+        };
+      });
+
+      // control_state도 AI 판단 결과로 업데이트
+      if (decision.control_type && decision.action) {
+        setStatus(prev => {
+          if (!prev) return prev;
+          const ct = decision.control_type as keyof typeof prev.control_state;
+          if (!(ct in prev.control_state)) return prev;
+          return {
+            ...prev,
+            control_state: {
+              ...prev.control_state,
+              [ct]: { ...prev.control_state[ct], ...decision.action },
+            },
+          };
+        });
+      }
+    });
+  }, []);
 
   const toggle = useCallback(async () => {
     try {
@@ -72,5 +117,5 @@ export function useAIAgent() {
     }
   }, [fetchStatus]);
 
-  return { status, loading, toggle, updateCropProfile, override, refetch: fetchStatus };
+  return { status, decisions, loading, toggle, updateCropProfile, override, refetch: fetchStatus };
 }

--- a/frontend/src/hooks/useManualControl.ts
+++ b/frontend/src/hooks/useManualControl.ts
@@ -1,0 +1,212 @@
+// Design Ref: §4.3 — useManualControl 훅
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ManualControlState, ControlCommand, ControlEvent } from '@/types';
+
+const API_BASE = 'https://iot.lilpa.moe/api/v1';
+
+export function useManualControl() {
+  const [controlState, setControlState] = useState<ManualControlState | null>(null);
+  const [simMode, setSimMode] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // 디바운스용 타이머 ref
+  const debounceTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  // 수동 조작 시각 기록 — AI rule SSE 방어용
+  const manualTimestamps = useRef<Record<string, number>>({});
+
+  // 초기 로드: GET /control/state
+  const fetchState = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/control/state`, { credentials: 'omit' });
+      if (res.ok) {
+        const data = await res.json();
+        setControlState(data);
+      }
+    } catch {
+      // 연결 실패 시 무시
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchState();
+  }, [fetchState]);
+
+  // API POST 공통
+  const _postControl = useCallback((
+    controlType: string,
+    action: Record<string, unknown>,
+  ) => {
+    return fetch(`${API_BASE}/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit',
+      body: JSON.stringify({
+        control_type: controlType,
+        action,
+        source: 'manual',
+      }),
+    }).catch(() => {
+      fetchState();
+    });
+  }, [fetchState]);
+
+  // 낙관적 업데이트 공통
+  const _optimisticUpdate = useCallback((
+    controlType: ControlCommand['control_type'],
+    action: Record<string, unknown>,
+  ) => {
+    manualTimestamps.current[controlType] = Date.now();
+    setControlState(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [controlType]: { ...prev[controlType], ...action, source: 'manual', locked: true },
+      };
+    });
+  }, []);
+
+  // 슬라이더용 — 디바운스 300ms (드래그 중 연속 호출 방지)
+  const sendCommand = useCallback((
+    controlType: ControlCommand['control_type'],
+    action: Record<string, unknown>,
+  ) => {
+    _optimisticUpdate(controlType, action);
+
+    const timerKey = controlType;
+    if (debounceTimers.current[timerKey]) {
+      clearTimeout(debounceTimers.current[timerKey]);
+    }
+    debounceTimers.current[timerKey] = setTimeout(() => {
+      _postControl(controlType, action);
+    }, 300);
+  }, [_optimisticUpdate, _postControl]);
+
+  // 버튼용 — 즉시 실행 (밸브 토글, ON/OFF 등)
+  const sendCommandImmediate = useCallback((
+    controlType: ControlCommand['control_type'],
+    action: Record<string, unknown>,
+  ) => {
+    _optimisticUpdate(controlType, action);
+    _postControl(controlType, action);
+  }, [_optimisticUpdate, _postControl]);
+
+  // 시뮬레이션: ESP8266 버튼 누름 흉내
+  const simulateButton = useCallback((
+    controlType: ControlCommand['control_type'],
+  ) => {
+    if (!controlState) return;
+
+    const current = controlState[controlType];
+    const newActive = !current.active;
+
+    let toggleState: Record<string, unknown>;
+    switch (controlType) {
+      case 'ventilation':
+        toggleState = { window_open_pct: newActive ? 100 : 0, fan_speed: newActive ? 1500 : 0 };
+        break;
+      case 'irrigation':
+        toggleState = { valve_open: newActive };
+        break;
+      case 'lighting':
+        toggleState = { on: newActive, brightness_pct: newActive ? 60 : 0 };
+        break;
+      case 'shading':
+        toggleState = { shade_pct: newActive ? 50 : 0, insulation_pct: 0 };
+        break;
+    }
+
+    // 낙관적 업데이트
+    manualTimestamps.current[controlType] = Date.now();
+    setControlState(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [controlType]: { ...prev[controlType], ...toggleState, source: 'button', active: newActive, led_on: newActive, locked: true },
+      };
+    });
+
+    fetch(`${API_BASE}/control/report`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'farmos-iot-default-key',
+      },
+      credentials: 'omit',
+      body: JSON.stringify({
+        device_id: 'simulator',
+        control_type: controlType,
+        state: toggleState,
+        source: 'button',
+      }),
+    }).catch(() => {
+      fetchState();
+    });
+  }, [controlState, fetchState]);
+
+  // 잠금 해제 → AI 규칙이 다시 제어
+  const unlockControl = useCallback((
+    controlType: ControlCommand['control_type'],
+  ) => {
+    // 낙관적 업데이트
+    setControlState(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [controlType]: { ...prev[controlType], locked: false },
+      };
+    });
+
+    fetch(`${API_BASE}/control/unlock`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit',
+      body: JSON.stringify({ control_type: controlType }),
+    }).catch(() => {
+      fetchState();
+    });
+  }, [fetchState]);
+
+  // SSE control 이벤트로 상태 업데이트
+  // 수동 조작 후 5초간 AI rule/tool 소스의 SSE는 무시 (슬라이더 복귀 방지)
+  const handleControlEvent = useCallback((event: ControlEvent) => {
+    const ct = event.control_type as keyof ManualControlState;
+    const isAISource = ['rule', 'tool', 'ai'].includes(event.source);
+    const lastManual = manualTimestamps.current[ct] || 0;
+    const elapsed = Date.now() - lastManual;
+
+    if (isAISource && elapsed < 5000) {
+      return; // 수동 조작 후 5초간 AI SSE 무시
+    }
+
+    setControlState(prev => {
+      if (!prev) return prev;
+      if (!(ct in prev)) return prev;
+      return {
+        ...prev,
+        [ct]: { ...prev[ct], ...event.state, source: event.source, updated_at: event.timestamp },
+      };
+    });
+  }, []);
+
+  // cleanup timers
+  useEffect(() => {
+    return () => {
+      Object.values(debounceTimers.current).forEach(clearTimeout);
+    };
+  }, []);
+
+  return {
+    controlState,
+    simMode,
+    setSimMode,
+    loading,
+    sendCommand,
+    sendCommandImmediate,
+    simulateButton,
+    unlockControl,
+    handleControlEvent,
+    refetch: fetchState,
+  };
+}

--- a/frontend/src/hooks/useManualControl.ts
+++ b/frontend/src/hooks/useManualControl.ts
@@ -1,5 +1,6 @@
 // Design Ref: §4.3 — useManualControl 훅
 import { useState, useEffect, useCallback, useRef } from 'react';
+import toast from 'react-hot-toast';
 import type { ManualControlState, ControlCommand, ControlEvent } from '@/types';
 
 const API_BASE = 'https://iot.lilpa.moe/api/v1';
@@ -47,8 +48,20 @@ export function useManualControl() {
         action,
         source: 'manual',
       }),
-    }).catch(() => {
-      fetchState();
+    }).then(async (res) => {
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        toast.error(body.detail || body.message || `제어 요청 실패 (${res.status})`);
+        fetchState();
+        return Promise.reject(new Error(body.detail || `HTTP ${res.status}`));
+      }
+      return res;
+    }).catch((err) => {
+      if (err instanceof TypeError) {
+        toast.error('서버에 연결할 수 없습니다');
+        fetchState();
+      }
+      throw err;
     });
   }, [fetchState]);
 
@@ -140,7 +153,14 @@ export function useManualControl() {
         state: toggleState,
         source: 'button',
       }),
+    }).then(async (res) => {
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        toast.error(body.detail || body.message || `시뮬레이션 요청 실패 (${res.status})`);
+        fetchState();
+      }
     }).catch(() => {
+      toast.error('서버에 연결할 수 없습니다');
       fetchState();
     });
   }, [controlState, fetchState]);
@@ -163,7 +183,14 @@ export function useManualControl() {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'omit',
       body: JSON.stringify({ control_type: controlType }),
+    }).then(async (res) => {
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        toast.error(body.detail || body.message || `잠금 해제 실패 (${res.status})`);
+        fetchState();
+      }
     }).catch(() => {
+      toast.error('서버에 연결할 수 없습니다');
       fetchState();
     });
   }, [fetchState]);

--- a/frontend/src/hooks/useSensorData.ts
+++ b/frontend/src/hooks/useSensorData.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { SensorReading, IrrigationEvent, SensorAlert } from '@/types';
+import type { SensorReading, IrrigationEvent, SensorAlert, ControlEvent } from '@/types';
 
-const API_BASE = 'http://iot.lilpa.moe/api/v1';
+const API_BASE = 'https://iot.lilpa.moe/api/v1';
 const FULL_SYNC_INTERVAL = 60000; // 전체 동기화는 60초마다 (fallback)
 
 interface SensorData {
@@ -10,6 +10,24 @@ interface SensorData {
   alerts: SensorAlert[];
   irrigations: IrrigationEvent[];
   connected: boolean;
+}
+
+// Design Ref: §4.4 — SSE control 이벤트 콜백 지원
+type ControlEventHandler = (event: ControlEvent) => void;
+const _controlHandlers: Set<ControlEventHandler> = new Set();
+
+export function onControlEvent(handler: ControlEventHandler) {
+  _controlHandlers.add(handler);
+  return () => { _controlHandlers.delete(handler); };
+}
+
+// SSE ai_decision 이벤트 콜백
+type AnyEventHandler = (data: unknown) => void;
+const _aiDecisionHandlers: Set<AnyEventHandler> = new Set();
+
+export function onAIDecisionEvent(handler: AnyEventHandler) {
+  _aiDecisionHandlers.add(handler);
+  return () => { _aiDecisionHandlers.delete(handler); };
 }
 
 export function useSensorData() {
@@ -88,6 +106,16 @@ export function useSensorData() {
         ...prev,
         irrigations: [event, ...prev.irrigations],
       }));
+    });
+
+    es.addEventListener('control', (e) => {
+      const controlEvent = JSON.parse(e.data) as ControlEvent;
+      _controlHandlers.forEach(handler => handler(controlEvent));
+    });
+
+    es.addEventListener('ai_decision', (e) => {
+      const decision = JSON.parse(e.data);
+      _aiDecisionHandlers.forEach(handler => handler(decision));
     });
 
     es.onopen = () => {

--- a/frontend/src/hooks/useSensorData.ts
+++ b/frontend/src/hooks/useSensorData.ts
@@ -83,39 +83,59 @@ export function useSensorData() {
     eventSourceRef.current = es;
 
     es.addEventListener('sensor', (e) => {
-      const reading = JSON.parse(e.data) as SensorReading;
-      setData(prev => ({
-        ...prev,
-        latest: reading,
-        history: [...prev.history.slice(-(99)), reading],
-        connected: true,
-      }));
+      try {
+        const reading = JSON.parse(e.data) as SensorReading;
+        setData(prev => ({
+          ...prev,
+          latest: reading,
+          history: [...prev.history.slice(-(99)), reading],
+          connected: true,
+        }));
+      } catch (err) {
+        console.warn('[SSE] sensor parse error:', err);
+      }
     });
 
     es.addEventListener('alert', (e) => {
-      const alert = JSON.parse(e.data) as SensorAlert;
-      setData(prev => ({
-        ...prev,
-        alerts: [alert, ...prev.alerts],
-      }));
+      try {
+        const alert = JSON.parse(e.data) as SensorAlert;
+        setData(prev => ({
+          ...prev,
+          alerts: [alert, ...prev.alerts],
+        }));
+      } catch (err) {
+        console.warn('[SSE] alert parse error:', err);
+      }
     });
 
     es.addEventListener('irrigation', (e) => {
-      const event = JSON.parse(e.data) as IrrigationEvent;
-      setData(prev => ({
-        ...prev,
-        irrigations: [event, ...prev.irrigations],
-      }));
+      try {
+        const event = JSON.parse(e.data) as IrrigationEvent;
+        setData(prev => ({
+          ...prev,
+          irrigations: [event, ...prev.irrigations],
+        }));
+      } catch (err) {
+        console.warn('[SSE] irrigation parse error:', err);
+      }
     });
 
     es.addEventListener('control', (e) => {
-      const controlEvent = JSON.parse(e.data) as ControlEvent;
-      _controlHandlers.forEach(handler => handler(controlEvent));
+      try {
+        const controlEvent = JSON.parse(e.data) as ControlEvent;
+        _controlHandlers.forEach(handler => handler(controlEvent));
+      } catch (err) {
+        console.warn('[SSE] control parse error:', err);
+      }
     });
 
     es.addEventListener('ai_decision', (e) => {
-      const decision = JSON.parse(e.data);
-      _aiDecisionHandlers.forEach(handler => handler(decision));
+      try {
+        const decision = JSON.parse(e.data);
+        _aiDecisionHandlers.forEach(handler => handler(decision));
+      } catch (err) {
+        console.warn('[SSE] ai_decision parse error:', err);
+      }
     });
 
     es.onopen = () => {

--- a/frontend/src/modules/iot/AIAgentPanel.tsx
+++ b/frontend/src/modules/iot/AIAgentPanel.tsx
@@ -132,7 +132,7 @@ function DecisionItem({ decision }: { decision: AIDecision }) {
 }
 
 export default function AIAgentPanel() {
-  const { status, loading, toggle, updateCropProfile } = useAIAgent();
+  const { status, decisions, loading, toggle, updateCropProfile } = useAIAgent();
   const [profileOpen, setProfileOpen] = useState(false);
   const [showAllDecisions, setShowAllDecisions] = useState(false);
 
@@ -157,8 +157,7 @@ export default function AIAgentPanel() {
     );
   }
 
-  const { control_state: cs, latest_decision, crop_profile } = status;
-  const decisions: AIDecision[] = latest_decision ? [latest_decision] : [];
+  const { control_state: cs, crop_profile } = status;
 
   return (
     <>
@@ -294,7 +293,7 @@ export default function AIAgentPanel() {
         )}
 
         {/* 최근 판단 이력 */}
-        {status.enabled && latest_decision && (
+        {status.enabled && decisions.length > 0 && (
           <div>
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
@@ -302,9 +301,17 @@ export default function AIAgentPanel() {
                 <span className="text-sm font-semibold text-gray-700">최근 판단</span>
                 <span className="text-xs text-gray-400">({status.total_decisions}건)</span>
               </div>
+              {decisions.length > 5 && (
+                <button
+                  onClick={() => setShowAllDecisions(!showAllDecisions)}
+                  className="text-xs text-blue-500 hover:text-blue-700"
+                >
+                  {showAllDecisions ? '접기' : `전체 ${decisions.length}건 보기`}
+                </button>
+              )}
             </div>
-            <div className="bg-gray-50 rounded-xl p-3">
-              {decisions.map(d => (
+            <div className="bg-gray-50 rounded-xl p-3 max-h-80 overflow-y-auto">
+              {(showAllDecisions ? decisions : decisions.slice(0, 5)).map(d => (
                 <DecisionItem key={d.id} decision={d} />
               ))}
             </div>

--- a/frontend/src/modules/iot/IoTDashboardPage.tsx
+++ b/frontend/src/modules/iot/IoTDashboardPage.tsx
@@ -3,6 +3,7 @@ import { MdWaterDrop, MdThermostat, MdOpacity, MdWbSunny, MdWarning, MdWifiOff, 
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, BarChart, Bar, Cell } from 'recharts';
 import { useSensorData } from '@/hooks/useSensorData';
 import AIAgentPanel from './AIAgentPanel';
+import ManualControlPanel from './ManualControlPanel';
 
 function SensorCard({ icon: Icon, label, value, unit, color, threshold, warning, disabled }: {
   icon: React.ElementType; label: string; value: number | null; unit: string;
@@ -437,6 +438,9 @@ export default function IoTDashboardPage() {
           )}
         </div>
       </div>
+
+      {/* 수동 제어 패널 */}
+      <ManualControlPanel />
 
       {/* AI Agent 제어 패널 */}
       <AIAgentPanel />

--- a/frontend/src/modules/iot/ManualControlPanel.tsx
+++ b/frontend/src/modules/iot/ManualControlPanel.tsx
@@ -1,0 +1,425 @@
+// Design Ref: §4.1 — ManualControlPanel (수동 제어 UI + 시뮬레이션 모드)
+import { useEffect, useState, useCallback } from 'react';
+import {
+  MdAir,
+  MdWaterDrop,
+  MdLightMode,
+  MdShield,
+  MdTune,
+  MdBugReport,
+  MdCircle,
+  MdTouchApp,
+  MdLock,
+  MdLockOpen,
+} from 'react-icons/md';
+import { useManualControl } from '@/hooks/useManualControl';
+import { onControlEvent } from '@/hooks/useSensorData';
+import type { ManualControlState } from '@/types';
+
+function SourceBadge({ source }: { source: string }) {
+  const styles: Record<string, string> = {
+    manual: 'bg-green-100 text-green-700',
+    button: 'bg-blue-100 text-blue-700',
+    rule: 'bg-yellow-100 text-yellow-700',
+    ai: 'bg-purple-100 text-purple-700',
+    tool: 'bg-indigo-100 text-indigo-700',
+  };
+  const labels: Record<string, string> = {
+    manual: '수동',
+    button: '버튼',
+    rule: '규칙',
+    ai: 'AI',
+    tool: 'AI Tool',
+  };
+  return (
+    <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${styles[source] || 'bg-gray-100 text-gray-600'}`}>
+      {labels[source] || source}
+    </span>
+  );
+}
+
+function LedIndicator({ on }: { on: boolean }) {
+  return (
+    <MdCircle className={`text-xs ${on ? 'text-green-500' : 'text-gray-300'}`} />
+  );
+}
+
+/** 슬라이더: 드래그 중은 로컬 state, 놓으면 서버 전송 */
+function ControlSlider({
+  value,
+  onChange,
+  color,
+  disabled,
+}: {
+  value: number;
+  onChange: (val: number) => void;
+  color: string;
+  disabled?: boolean;
+}) {
+  const [localValue, setLocalValue] = useState(value);
+  const [dragging, setDragging] = useState(false);
+
+  // 외부 값 변경 시 로컬 동기화 (드래그 중이 아닐 때만)
+  useEffect(() => {
+    if (!dragging) {
+      setLocalValue(value);
+    }
+  }, [value, dragging]);
+
+  return (
+    <input
+      type="range"
+      min={0}
+      max={100}
+      step={10}
+      value={dragging ? localValue : value}
+      onChange={(e) => {
+        const v = Number(e.target.value);
+        setLocalValue(v);
+        setDragging(true);
+      }}
+      onMouseUp={() => {
+        setDragging(false);
+        onChange(localValue);
+      }}
+      onTouchEnd={() => {
+        setDragging(false);
+        onChange(localValue);
+      }}
+      className={`w-full h-1.5 bg-gray-200 rounded-full appearance-none cursor-pointer accent-${color}`}
+      disabled={disabled}
+    />
+  );
+}
+
+function LockButton({ locked, onToggle }: { locked: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={onToggle}
+      className={`ml-auto p-1 rounded transition-all ${
+        locked
+          ? 'text-orange-500 hover:bg-orange-50'
+          : 'text-gray-300 hover:bg-gray-50'
+      }`}
+      title={locked ? '수동 잠금 중 (클릭하여 AI 제어 허용)' : 'AI 제어 허용 중'}
+    >
+      {locked ? <MdLock className="text-base" /> : <MdLockOpen className="text-base" />}
+    </button>
+  );
+}
+
+function VentilationCard({
+  state,
+  onSlider,
+  onButton,
+  onUnlock,
+}: {
+  state: ManualControlState['ventilation'];
+  onSlider: (action: Record<string, unknown>) => void;
+  onButton: (action: Record<string, unknown>) => void;
+  onUnlock: () => void;
+}) {
+  return (
+    <div className={`bg-white rounded-xl border p-4 space-y-3 ${state.locked ? 'ring-1 ring-orange-300' : ''}`}>
+      <div className="flex items-center gap-2">
+        <MdAir className="text-xl text-blue-500" />
+        <span className="font-semibold text-gray-800 text-sm">환기</span>
+        <LedIndicator on={state.led_on} />
+        <SourceBadge source={state.source} />
+        <LockButton locked={state.locked} onToggle={onUnlock} />
+      </div>
+
+      <div>
+        <div className="flex justify-between text-sm text-gray-600 mb-1">
+          <span>창문 개폐율</span>
+          <span className="font-semibold text-gray-800">{state.window_open_pct}%</span>
+        </div>
+        <ControlSlider
+          value={state.window_open_pct}
+          onChange={(v) => onSlider({ window_open_pct: v })}
+          color="blue-500"
+        />
+      </div>
+
+      <div className="flex justify-between text-sm text-gray-600">
+        <span>팬 속도</span>
+        <span className="font-semibold text-gray-800">{state.fan_speed} RPM</span>
+      </div>
+      <div className="flex gap-1">
+        {[0, 500, 1000, 1500, 3000].map((rpm) => (
+          <button
+            key={rpm}
+            onClick={() => onButton({ fan_speed: rpm })}
+            className={`flex-1 text-xs py-1 rounded ${
+              state.fan_speed === rpm
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            {rpm === 0 ? 'OFF' : rpm}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IrrigationCard({
+  state,
+  onCommand,
+  onUnlock,
+}: {
+  state: ManualControlState['irrigation'];
+  onCommand: (action: Record<string, unknown>) => void;
+  onUnlock: () => void;
+}) {
+  return (
+    <div className={`bg-white rounded-xl border p-4 space-y-3 ${state.locked ? 'ring-1 ring-orange-300' : ''}`}>
+      <div className="flex items-center gap-2">
+        <MdWaterDrop className="text-xl text-cyan-500" />
+        <span className="font-semibold text-gray-800 text-sm">관수/양액</span>
+        <LedIndicator on={state.led_on} />
+        <SourceBadge source={state.source} />
+        <LockButton locked={state.locked} onToggle={onUnlock} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-600">밸브</span>
+        <button
+          onClick={() => onCommand({ valve_open: !state.valve_open })}
+          className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-all ${
+            state.valve_open
+              ? 'bg-cyan-500 text-white'
+              : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+          }`}
+        >
+          {state.valve_open ? '열림' : '닫힘'}
+        </button>
+      </div>
+
+      <div className="flex justify-between text-sm text-gray-600">
+        <span>금일 급수량</span>
+        <span className="font-semibold text-gray-800">{state.daily_total_L.toFixed(1)}L</span>
+      </div>
+    </div>
+  );
+}
+
+function LightingCard({
+  state,
+  onCommand,
+  onUnlock,
+}: {
+  state: ManualControlState['lighting'];
+  onCommand: (action: Record<string, unknown>) => void;
+  onUnlock: () => void;
+}) {
+  return (
+    <div className={`bg-white rounded-xl border p-4 space-y-3 ${state.locked ? 'ring-1 ring-orange-300' : ''}`}>
+      <div className="flex items-center gap-2">
+        <MdLightMode className="text-xl text-amber-500" />
+        <span className="font-semibold text-gray-800 text-sm">조명</span>
+        <LedIndicator on={state.led_on} />
+        <SourceBadge source={state.source} />
+        <LockButton locked={state.locked} onToggle={onUnlock} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-600">상태</span>
+        <button
+          onClick={() => onCommand({ on: !state.on, brightness_pct: !state.on ? 60 : 0 })}
+          className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-all ${
+            state.on
+              ? 'bg-amber-500 text-white'
+              : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+          }`}
+        >
+          {state.on ? 'ON' : 'OFF'}
+        </button>
+      </div>
+
+      <div>
+        <div className="flex justify-between text-sm text-gray-600 mb-1">
+          <span>밝기</span>
+          <span className="font-semibold text-gray-800">{state.brightness_pct}%</span>
+        </div>
+        <ControlSlider
+          value={state.brightness_pct}
+          onChange={(v) => onCommand({ brightness_pct: v, on: v > 0 })}
+          color="amber-500"
+          disabled={!state.on}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ShadingCard({
+  state,
+  onCommand,
+  onUnlock,
+}: {
+  state: ManualControlState['shading'];
+  onCommand: (action: Record<string, unknown>) => void;
+  onUnlock: () => void;
+}) {
+  return (
+    <div className={`bg-white rounded-xl border p-4 space-y-3 ${state.locked ? 'ring-1 ring-orange-300' : ''}`}>
+      <div className="flex items-center gap-2">
+        <MdShield className="text-xl text-emerald-500" />
+        <span className="font-semibold text-gray-800 text-sm">차광/보온</span>
+        <LedIndicator on={state.led_on} />
+        <SourceBadge source={state.source} />
+        <LockButton locked={state.locked} onToggle={onUnlock} />
+      </div>
+
+      <div>
+        <div className="flex justify-between text-sm text-gray-600 mb-1">
+          <span>차광막</span>
+          <span className="font-semibold text-gray-800">{state.shade_pct}%</span>
+        </div>
+        <ControlSlider
+          value={state.shade_pct}
+          onChange={(v) => onCommand({ shade_pct: v })}
+          color="emerald-500"
+        />
+      </div>
+
+      <div>
+        <div className="flex justify-between text-sm text-gray-600 mb-1">
+          <span>보온커튼</span>
+          <span className="font-semibold text-gray-800">{state.insulation_pct}%</span>
+        </div>
+        <ControlSlider
+          value={state.insulation_pct}
+          onChange={(v) => onCommand({ insulation_pct: v })}
+          color="orange-500"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function ManualControlPanel() {
+  const {
+    controlState,
+    simMode,
+    setSimMode,
+    loading,
+    sendCommand,
+    sendCommandImmediate,
+    simulateButton,
+    unlockControl,
+    handleControlEvent,
+  } = useManualControl();
+
+  // SSE control 이벤트 구독
+  useEffect(() => {
+    return onControlEvent(handleControlEvent);
+  }, [handleControlEvent]);
+
+  if (loading) {
+    return (
+      <div className="card animate-pulse">
+        <div className="h-6 bg-gray-200 rounded w-48 mb-4" />
+        <div className="h-40 bg-gray-100 rounded" />
+      </div>
+    );
+  }
+
+  if (!controlState) {
+    return (
+      <div className="card">
+        <div className="flex items-center gap-2 text-gray-400">
+          <MdTune className="text-2xl" />
+          <h3 className="font-semibold">수동 제어</h3>
+          <span className="ml-auto text-xs">IoT 서버 연결 대기중...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <MdTune className="text-2xl text-blue-600" />
+          <h3 className="section-title !mb-0">수동 제어</h3>
+        </div>
+        <button
+          onClick={() => setSimMode(!simMode)}
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+            simMode
+              ? 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+              : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+          }`}
+          title="ESP8266 버튼을 브라우저에서 시뮬레이션"
+        >
+          <MdBugReport className="text-sm" />
+          시뮬레이션 {simMode ? 'ON' : 'OFF'}
+        </button>
+      </div>
+
+      {/* 4대 제어 카드 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <VentilationCard
+          state={controlState.ventilation}
+          onSlider={(action) => sendCommand('ventilation', action)}
+          onButton={(action) => sendCommandImmediate('ventilation', action)}
+          onUnlock={() => unlockControl('ventilation')}
+        />
+        <IrrigationCard
+          state={controlState.irrigation}
+          onCommand={(action) => sendCommandImmediate('irrigation', action)}
+          onUnlock={() => unlockControl('irrigation')}
+        />
+        <LightingCard
+          state={controlState.lighting}
+          onCommand={(action) => sendCommandImmediate('lighting', action)}
+          onUnlock={() => unlockControl('lighting')}
+        />
+        <ShadingCard
+          state={controlState.shading}
+          onCommand={(action) => sendCommand('shading', action)}
+          onUnlock={() => unlockControl('shading')}
+        />
+      </div>
+
+      {/* 시뮬레이션 바 */}
+      {simMode && (
+        <div className="bg-orange-50 border border-orange-200 rounded-xl p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <MdTouchApp className="text-orange-500" />
+            <span className="text-sm font-semibold text-orange-700">ESP8266 버튼 시뮬레이션</span>
+            <span className="text-xs text-orange-500">(하드웨어 미연결 시 테스트용)</span>
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            {(['ventilation', 'irrigation', 'lighting', 'shading'] as const).map((ct) => {
+              const labels = { ventilation: '환기', irrigation: '관수', lighting: '조명', shading: '차광' };
+              const colors = { ventilation: 'blue', irrigation: 'cyan', lighting: 'amber', shading: 'emerald' };
+              const isActive = controlState[ct].active;
+              const color = colors[ct];
+              return (
+                <button
+                  key={ct}
+                  onClick={() => simulateButton(ct)}
+                  className={`py-2.5 rounded-lg text-sm font-medium transition-all border-2 ${
+                    isActive
+                      ? `bg-${color}-100 border-${color}-400 text-${color}-700`
+                      : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'
+                  }`}
+                >
+                  <div className="text-center">
+                    <LedIndicator on={isActive} />
+                    <div className="mt-1">{labels[ct]}</div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/modules/iot/ManualControlPanel.tsx
+++ b/frontend/src/modules/iot/ManualControlPanel.tsx
@@ -44,6 +44,13 @@ function LedIndicator({ on }: { on: boolean }) {
   );
 }
 
+const ACCENT_CLASSES: Record<string, string> = {
+  'blue-500': 'accent-blue-500',
+  'amber-500': 'accent-amber-500',
+  'emerald-500': 'accent-emerald-500',
+  'orange-500': 'accent-orange-500',
+};
+
 /** 슬라이더: 드래그 중은 로컬 state, 놓으면 서버 전송 */
 function ControlSlider({
   value,
@@ -66,6 +73,11 @@ function ControlSlider({
     }
   }, [value, dragging]);
 
+  const commit = useCallback(() => {
+    setDragging(false);
+    onChange(localValue);
+  }, [localValue, onChange]);
+
   return (
     <input
       type="range"
@@ -78,15 +90,10 @@ function ControlSlider({
         setLocalValue(v);
         setDragging(true);
       }}
-      onMouseUp={() => {
-        setDragging(false);
-        onChange(localValue);
-      }}
-      onTouchEnd={() => {
-        setDragging(false);
-        onChange(localValue);
-      }}
-      className={`w-full h-1.5 bg-gray-200 rounded-full appearance-none cursor-pointer accent-${color}`}
+      onMouseUp={commit}
+      onTouchEnd={commit}
+      onBlur={commit}
+      className={`w-full h-1.5 bg-gray-200 rounded-full appearance-none cursor-pointer ${ACCENT_CLASSES[color] || ''}`}
       disabled={disabled}
     />
   );
@@ -397,16 +404,20 @@ export default function ManualControlPanel() {
           <div className="grid grid-cols-4 gap-2">
             {(['ventilation', 'irrigation', 'lighting', 'shading'] as const).map((ct) => {
               const labels = { ventilation: '환기', irrigation: '관수', lighting: '조명', shading: '차광' };
-              const colors = { ventilation: 'blue', irrigation: 'cyan', lighting: 'amber', shading: 'emerald' };
+              const activeStyles: Record<string, string> = {
+                ventilation: 'bg-blue-100 border-blue-400 text-blue-700',
+                irrigation: 'bg-cyan-100 border-cyan-400 text-cyan-700',
+                lighting: 'bg-amber-100 border-amber-400 text-amber-700',
+                shading: 'bg-emerald-100 border-emerald-400 text-emerald-700',
+              };
               const isActive = controlState[ct].active;
-              const color = colors[ct];
               return (
                 <button
                   key={ct}
                   onClick={() => simulateButton(ct)}
                   className={`py-2.5 rounded-lg text-sm font-medium transition-all border-2 ${
                     isActive
-                      ? `bg-${color}-100 border-${color}-400 text-${color}-700`
+                      ? activeStyles[ct]
                       : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'
                   }`}
                 >

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -411,6 +411,57 @@ export interface ImportantChange {
   direction: "up" | "down";
 }
 
+// Manual Control (IoT 수동 제어)
+export interface ControlItemState {
+  active: boolean;
+  led_on: boolean;
+  locked: boolean;
+  source: "manual" | "button" | "ai" | "rule" | "tool";
+  updated_at: string | null;
+}
+
+export interface VentilationState extends ControlItemState {
+  window_open_pct: number;
+  fan_speed: number;
+}
+
+export interface IrrigationControlState extends ControlItemState {
+  valve_open: boolean;
+  daily_total_L: number;
+  last_watered: string | null;
+  nutrient: { N: number; P: number; K: number };
+}
+
+export interface LightingState extends ControlItemState {
+  on: boolean;
+  brightness_pct: number;
+}
+
+export interface ShadingState extends ControlItemState {
+  shade_pct: number;
+  insulation_pct: number;
+}
+
+export interface ManualControlState {
+  ventilation: VentilationState;
+  irrigation: IrrigationControlState;
+  lighting: LightingState;
+  shading: ShadingState;
+}
+
+export interface ControlCommand {
+  control_type: "ventilation" | "irrigation" | "lighting" | "shading";
+  action: Record<string, unknown>;
+  source: "manual" | "button";
+}
+
+export interface ControlEvent {
+  control_type: string;
+  state: Record<string, unknown>;
+  source: string;
+  timestamp: string;
+}
+
 // AI Agent
 export interface AIControlState {
   ventilation: { window_open_pct: number; fan_speed: number };


### PR DESCRIPTION
## 변경 요약
- FarmOS IoT 센서 대시보드 내부에서 사용자가 수동으로 환기,관수/양액, 조명, 차광/보온 기능을 사용할 수 있게 수정.

## 관련 이슈
- Closes #54 

## 변경 내용
- FarmOS IoT 센서 대시보드 내부에서 사용자가 수동으로 환기,관수/양액, 조명, 차광/보온 기능을 사용할 수 있게 수정 후 테스트 진행.

## 테스트
- [x] 로컬 실행 (백엔드)
- [x] 로컬 실행 (프론트)
- [x] 주요 시나리오 확인:
  - 사용자가 슬라이드를 클릭 + 드래그를 수행하고, 클릭을 때는 순간 슬라이더 값 조정.
  - 이후 자물쇠 버튼이 활성화가 되고, 이떄는 AI Agent의 제어가 들어오지 않게 구성 및 테스트.

## 스크린샷/녹화(선택)
- 

## 체크리스트
- [x] 영향 범위(사용자/권한/성능/보안) 검토
- [x] 실패 시 롤백/대안 고려(필요 시)
- [x] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시) -> 프로젝트 루트 최상단 docs 폴더에 iot 관련 문서 추가.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * IoT 수동 제어 시스템 추가 - 환기, 관개, 조명, 차광 장치를 웹 인터페이스와 ESP8266 버튼으로 제어 가능
  * 수동 제어 패널 UI 추가 - 슬라이더, 토글, 시뮬레이션 모드 포함
  * SSE 실시간 제어 상태 업데이트 기능

* **개선 사항**
  * AI 에이전트 의사결정 기록 기능 확장
  * HTTPS 통신으로 보안 강화
  * 낙관적 UI 업데이트로 반응성 개선

* **문서**
  * 기능 계획, 설계, 분석, 완료 보고서 작성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->