### PR TITLE
상품 리뷰 자동화 Openrouter -> LiteLLM 변경

### DIFF
--- a/backend/app/api/diagnosis.py
+++ b/backend/app/api/diagnosis.py
@@ -172,7 +172,7 @@ async def add_chat_message(
         
         api_key = settings.OPENROUTER_API_KEY
         model_name = settings.OPENROUTER_PEST_RAG_MODEL
-        
+
         ai_reply = "API 키가 없어 답변할 수 없습니다."
         if api_key != "dummy" and api_key:
             try:

--- a/backend/app/api/review_analysis.py
+++ b/backend/app/api/review_analysis.py
@@ -386,6 +386,12 @@ async def search_reviews(
 
     멀티테넌트: seller_id가 있으면 해당 판매자의 상품 리뷰만 검색합니다.
     """
+    # 컬렉션 이름 변경(예: reviews_bge_m3 → reviews_voyage_v35) 후 최초 요청 시
+    # 새 컬렉션이 비어 있으므로 여기서 전체 재임베딩을 수행하는 것이
+    # 현재의 "empty-new-collection window" 완화 장치이다.
+    # 주의: 재임베딩은 수 분이 걸릴 수 있어 첫 요청이 지연된다.
+    # 운영 시에는 트래픽 컷오버 전에 docs/runbooks/review-embedding-migration.md
+    # 절차대로 수동 sync_from_db 를 선행하여 사용자 대기를 피한다.
     if _rag.get_count() == 0:
         await _rag.sync_from_db(db)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,11 +34,17 @@ class Settings(BaseSettings):
     KAMIS_API_KEY: str = ""
     KAMIS_CERT_ID: str = ""
 
-    # OpenRouter (LLM API)
+    # OpenRouter (LLM API) — 진단/일지/공통 LLM 클라이언트에서 사용
+    # NOTE: LiteLLM 프록시에 등록된 모델명을 그대로 사용해야 함 (접두사 없이)
     OPENROUTER_API_KEY: str = ""
     OPENROUTER_URL: str = "https://litellm.lilpa.moe/v1"
-    OPENROUTER_MODEL: str = "google/gemma-4-31b-it"
-    OPENROUTER_PEST_RAG_MODEL: str = "openai/gpt-4o"
+    OPENROUTER_MODEL: str = "gpt-5-nano"
+    OPENROUTER_PEST_RAG_MODEL: str = "gpt-5-nano"
+
+    # LiteLLM 프록시 — 리뷰 자동화(임베딩) 전용 네이밍 (실제 호스트는 OPENROUTER_URL 과 동일 가능)
+    LITELLM_API_KEY: str = ""
+    LITELLM_URL: str = "https://litellm.lilpa.moe/v1"
+    LITELLM_MODEL: str = "gpt-5-nano"
 
     # 외부 데이터 API (기상청, NCPMS, 농약안전정보시스템)
     WEATHER_API_KEY: str = ""
@@ -54,10 +60,19 @@ class Settings(BaseSettings):
     FOOD_SAFETY_API_KEY: str = ""
 
     # LLM Provider (리뷰 분석용)
-    LLM_PROVIDER: str = "ollama"  # ollama | openrouter | ollama_remote
+    LLM_PROVIDER: str = "openrouter"  # ollama | openrouter | ollama_remote
     LLM_MODEL: str = "llama3.1:8b"
     OLLAMA_BASE_URL: str = "http://localhost:11434"
     OLLAMA_REMOTE_URL: str = ""  # RunPod 등 원격 Ollama URL
+
+    # Review Embedding (LiteLLM 프록시 경유, VoyageAI 등)
+    EMBED_MODEL: str = "voyage-3.5"
+    EMBED_DIM: int = 1024
+
+    # LLM 리즈닝 강도 (GPT-5 계열 reasoning 모델용)
+    # minimal | low | medium | high  또는 "none"(파라미터 미전송)
+    # non-reasoning 모델(gemma, gpt-oss 등)은 무시됨
+    LLM_REASONING_EFFORT: str = "minimal"
 
     # Review Analysis
     REVIEW_ANALYSIS_BATCH_SIZE: int = 40

--- a/backend/app/core/llm_client_base.py
+++ b/backend/app/core/llm_client_base.py
@@ -195,25 +195,40 @@ class OpenRouterClient(BaseLLMClient):
         return await self.chat(messages)
 
     async def chat(self, messages: list[dict]) -> str:
-        """OpenRouter chat/completions 엔드포인트 호출."""
+        """OpenRouter chat/completions 엔드포인트 호출.
+
+        학습 포인트:
+            GPT-5 계열 등 리즈닝 모델은 기본적으로 내부 추론 토큰을 많이 소비합니다.
+            단순 JSON 생성 용도에선 리즈닝이 불필요하므로
+            settings.LLM_REASONING_EFFORT 로 "minimal" 로 낮춰 속도/비용을 확보합니다.
+
+            - reasoning_effort: minimal | low | medium | high
+            - None 으로 지정하면 파라미터를 아예 보내지 않아 기본값(medium) 사용
+            - non-reasoning 모델(gemma, gpt-oss 등)은 이 파라미터를 무시
+        """
         if not self.api_key:
             raise ValueError(
                 "OPENROUTER_API_KEY가 설정되지 않았습니다. "
                 ".env 파일에 OPENROUTER_API_KEY=sk-or-xxx를 추가하세요."
             )
 
+        payload: dict = {
+            "model": self.model,
+            "messages": messages,
+        }
+        effort = settings.LLM_REASONING_EFFORT.strip().lower()
+        if effort and effort != "none":
+            payload["reasoning_effort"] = effort
+
         try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
+            async with httpx.AsyncClient(timeout=120.0) as client:
                 resp = await client.post(
                     f"{self.base_url}/chat/completions",
                     headers={
                         "Authorization": f"Bearer {self.api_key}",
                         "Content-Type": "application/json",
                     },
-                    json={
-                        "model": self.model,
-                        "messages": messages,
-                    },
+                    json=payload,
                 )
                 resp.raise_for_status()
                 data = resp.json()

--- a/backend/app/core/review_analyzer.py
+++ b/backend/app/core/review_analyzer.py
@@ -39,6 +39,8 @@ import json
 import logging
 import time
 
+import httpx
+
 from app.core.llm_client_base import BaseLLMClient, get_llm_client
 from app.core.config import settings
 
@@ -280,6 +282,16 @@ class ReviewAnalyzer:
                 if attempt == max_retries:
                     logger.error("LLM 분석 최대 재시도 초과, 이 배치 건너뜀")
                     return None
+            except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.ConnectError) as e:
+                # Cloudflare 504 / 네트워크 일시 오류 등 — 지수 백오프 후 재시도
+                wait = 2 ** attempt
+                logger.warning(
+                    f"LLM HTTP 오류 (시도 {attempt + 1}/{max_retries + 1}): {e} → {wait}초 후 재시도"
+                )
+                if attempt == max_retries:
+                    logger.error("LLM HTTP 최대 재시도 초과, 이 배치 건너뜀")
+                    return None
+                await asyncio.sleep(wait)
 
     # ------------------------------------------------------------------
     # 프롬프트 포맷팅

--- a/backend/app/core/review_analyzer.py
+++ b/backend/app/core/review_analyzer.py
@@ -282,14 +282,30 @@ class ReviewAnalyzer:
                 if attempt == max_retries:
                     logger.error("LLM 분석 최대 재시도 초과, 이 배치 건너뜀")
                     return None
-            except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.ConnectError) as e:
-                # Cloudflare 504 / 네트워크 일시 오류 등 — 지수 백오프 후 재시도
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status != 429 and status < 500:
+                    body = (e.response.text or "")[:500]
+                    logger.error(
+                        f"LLM HTTP {status} 비재시도 오류, 이 배치 건너뜀: {body}"
+                    )
+                    return None
                 wait = 2 ** attempt
                 logger.warning(
-                    f"LLM HTTP 오류 (시도 {attempt + 1}/{max_retries + 1}): {e} → {wait}초 후 재시도"
+                    f"LLM HTTP {status} (시도 {attempt + 1}/{max_retries + 1}): {e} → {wait}초 후 재시도"
                 )
                 if attempt == max_retries:
                     logger.error("LLM HTTP 최대 재시도 초과, 이 배치 건너뜀")
+                    return None
+                await asyncio.sleep(wait)
+            except (httpx.TimeoutException, httpx.ConnectError) as e:
+                # Cloudflare 504 / 네트워크 일시 오류 등 — 지수 백오프 후 재시도
+                wait = 2 ** attempt
+                logger.warning(
+                    f"LLM 네트워크 오류 (시도 {attempt + 1}/{max_retries + 1}): {e} → {wait}초 후 재시도"
+                )
+                if attempt == max_retries:
+                    logger.error("LLM 네트워크 최대 재시도 초과, 이 배치 건너뜀")
                     return None
                 await asyncio.sleep(wait)
 

--- a/backend/app/core/review_rag.py
+++ b/backend/app/core/review_rag.py
@@ -52,49 +52,56 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-COLLECTION_NAME = "reviews_bge_m3"
-EMBED_MODEL = "bge-m3"
+COLLECTION_NAME = "reviews_voyage_v35"
 
 
-class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
-    """Ollama LLM을 사용하는 ChromaDB 임베딩 함수.
+class LiteLLMEmbeddingFunction(EmbeddingFunction[Documents]):
+    """LiteLLM 프록시 경유 임베딩 함수 (OpenAI 호환 /embeddings 엔드포인트).
 
     학습 포인트:
-        ChromaDB는 커스텀 임베딩 함수를 주입할 수 있습니다.
-        EmbeddingFunction을 상속하고 __call__을 구현하면,
-        add()나 query() 시 이 함수가 자동으로 호출됩니다.
+        LiteLLM은 인퍼런스를 하지 않고 HTTP 포워딩만 하는 프록시입니다.
+        실제 임베딩 연산은 LiteLLM config에 등록된 외부 제공자에서 수행됩니다.
+        예: VoyageAI, OpenAI, Cohere 등.
 
-        nomic-embed-text는 한국어를 지원하지 않아 모든 입력에 동일한 벡터를 반환합니다.
-        llama3.1:8b는 다국어를 지원하여 한국어 의미를 정확히 구분합니다.
+        N100 위에 LiteLLM이 올라가 있어도 N100은 요청을 외부로 중계만 하므로
+        CPU 부하가 거의 0이며, 저사양 PC여도 병목이 발생하지 않습니다.
 
-        예시 (검색어: "포장이 엉망이에요"):
-          nomic-embed-text: 모든 결과 동일 (한국어 미지원)
-          llama3.1:8b:      "멍투성이" 0.95, "당도 높아요" 0.89 ← 관련 리뷰가 상위
+        모델 전환은 .env 의 EMBED_MODEL / EMBED_DIM 만 바꾸면 되며,
+        차원이 바뀌면 COLLECTION_NAME 도 같이 바꿔서 전체 재임베딩합니다.
     """
 
-    def __init__(self, base_url: str | None = None, model: str = EMBED_MODEL):
-        self.base_url = base_url or settings.OLLAMA_BASE_URL
-        self.model = model
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+    ):
+        self.base_url = base_url or settings.LITELLM_URL
+        self.api_key = api_key or settings.LITELLM_API_KEY
+        self.model = model or settings.EMBED_MODEL
 
     def __call__(self, input: Documents) -> Embeddings:
         """텍스트 리스트를 임베딩 벡터 리스트로 변환 (배치)."""
         batch_size = 64
-        embeddings = []
+        embeddings: list[list[float]] = []
         for i in range(0, len(input), batch_size):
             batch = list(input[i:i + batch_size])
             try:
                 resp = httpx.post(
-                    f"{self.base_url}/api/embed",
+                    f"{self.base_url}/embeddings",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
                     json={"model": self.model, "input": batch},
                     timeout=120.0,
                 )
                 resp.raise_for_status()
-                batch_embeddings = resp.json()["embeddings"]
-                embeddings.extend(batch_embeddings)
+                data = resp.json()["data"]
+                embeddings.extend([d["embedding"] for d in data])
             except Exception as e:
-                logger.error(f"Ollama 배치 임베딩 실패: {e}")
-                dim = 1024 if "bge" in self.model else 768
-                embeddings.extend([[0.0] * dim for _ in batch])
+                logger.error(f"LiteLLM 임베딩 실패: {e}")
+                embeddings.extend([[0.0] * settings.EMBED_DIM for _ in batch])
         return embeddings
 
 
@@ -111,7 +118,7 @@ class ReviewRAG:
 
     def __init__(self):
         client = get_client()
-        self._embed_fn = OllamaEmbeddingFunction()
+        self._embed_fn = LiteLLMEmbeddingFunction()
         self.collection = client.get_or_create_collection(
             name=COLLECTION_NAME,
             embedding_function=self._embed_fn,
@@ -276,8 +283,10 @@ class ReviewRAG:
         where_filter = self._build_where_filter(filters)
 
         try:
-            # 벡터 검색 (top_k보다 넓게 가져와서 키워드 부스팅 후 재정렬)
-            fetch_count = min(top_k * 3, 150)
+            # 벡터 검색 (top_k보다 크게 가져와서 dedup 후에도 충분한 결과가 남도록)
+            # 더미/시드 데이터에 동일 문장이 상품별로 반복 저장된 경우를 대비해
+            # 넉넉히 fetch → 키워드 부스팅 → 텍스트 중복 제거 → top_k 반환
+            fetch_count = min(max(top_k * 10, 50), 300)
             results = self.collection.query(
                 query_texts=[query],
                 n_results=fetch_count,
@@ -295,9 +304,22 @@ class ReviewRAG:
                         break
                 r["similarity"] = round(r["similarity"] + boost, 4)
 
-            # 하이브리드 점수로 재정렬 후 top_k만 반환
+            # 하이브리드 점수로 재정렬
             vector_results.sort(key=lambda x: x["similarity"], reverse=True)
-            return vector_results[:top_k]
+
+            # 텍스트 기반 중복 제거 — 동일 content 는 가장 높은 점수 1건만 유지
+            # (상품은 달라도 리뷰 본문이 같은 시드 데이터의 시각적 중복을 제거)
+            seen_texts: set[str] = set()
+            deduped: list[dict] = []
+            for r in vector_results:
+                text_key = r.get("text", "").strip()
+                if text_key in seen_texts:
+                    continue
+                seen_texts.add(text_key)
+                deduped.append(r)
+                if len(deduped) >= top_k:
+                    break
+            return deduped
 
         except Exception as e:
             logger.error(f"리뷰 검색 실패: {e}")

--- a/backend/app/core/review_rag.py
+++ b/backend/app/core/review_rag.py
@@ -53,6 +53,10 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 COLLECTION_NAME = "reviews_voyage_v35"
+# Migration note:
+#   이전 컬렉션: "reviews_bge_m3" (1024-dim, BGE-M3) → 현재: "reviews_voyage_v35" (1024-dim, Voyage v3.5).
+#   임베딩 모델/차원이 달라지면 벡터가 호환되지 않으므로 컬렉션 이름을 반드시 바꿔야 한다.
+#   컷오버 절차와 구(舊) 컬렉션 정리 방법은 docs/runbooks/review-embedding-migration.md 참조.
 
 
 class LiteLLMEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -100,8 +104,11 @@ class LiteLLMEmbeddingFunction(EmbeddingFunction[Documents]):
                 data = resp.json()["data"]
                 embeddings.extend([d["embedding"] for d in data])
             except Exception as e:
-                logger.error(f"LiteLLM 임베딩 실패: {e}")
-                embeddings.extend([[0.0] * settings.EMBED_DIM for _ in batch])
+                logger.error(
+                    f"LiteLLM 임베딩 실패 (batch size={len(batch)}): {e}"
+                )
+                # 영벡터를 합성하면 컬렉션이 영구 오염되므로 호출자에게 예외를 전파한다.
+                raise
         return embeddings
 
 
@@ -109,11 +116,14 @@ class ReviewRAG:
     """리뷰 벡터 저장 및 의미 검색 서비스.
 
     학습 포인트:
-        이 클래스는 ChromaDB의 "reviews_nomic" 컬렉션을 관리합니다.
+        이 클래스는 ChromaDB의 COLLECTION_NAME (현재 "reviews_voyage_v35") 컬렉션을 관리합니다.
         컬렉션 = RDB의 테이블과 유사한 개념입니다.
 
-        Ollama nomic-embed-text 모델을 임베딩 함수로 사용합니다.
-        기본 영어 모델 대비 한국어 유사도 정확도가 크게 향상됩니다.
+        LiteLLM 프록시 경유 Voyage v3.5 (1024-dim) 를 임베딩 함수로 사용합니다.
+        이전에는 Ollama nomic-embed-text / BGE-M3 를 사용했으나, 한국어 리뷰에 대한
+        유사도 품질과 프록시 운영 편의성을 이유로 Voyage v3.5 로 전환했습니다.
+        모델/차원이 바뀌면 COLLECTION_NAME 도 함께 바꾸어 전체 재임베딩이 필요합니다.
+        운영 절차는 docs/runbooks/review-embedding-migration.md 참조.
     """
 
     def __init__(self):
@@ -230,7 +240,23 @@ class ReviewRAG:
                 for r in chunk
             ]
 
-            self.collection.add(documents=documents, metadatas=metadatas, ids=ids)
+            try:
+                self.collection.add(documents=documents, metadatas=metadatas, ids=ids)
+            except Exception as e:
+                # __call__ 에서 임베딩이 실패하면 예외가 올라온다.
+                # 해당 청크만 건너뛰고 다음 청크는 계속 처리한다 (영벡터 영구 저장 방지).
+                logger.error(
+                    f"청크 임베딩 실패, 해당 배치 건너뜀 ({len(chunk)}건): {e}"
+                )
+                progress = int(embedded / total * 100) if total else 100
+                yield {
+                    "progress": progress,
+                    "embedded": embedded,
+                    "total": total,
+                    "message": f"임베딩 실패로 {len(chunk)}건 건너뜀: {e}",
+                }
+                continue
+
             embedded += len(chunk)
             progress = int(embedded / total * 100)
 

--- a/docs/02-design/features/agent-action-history.design.md
+++ b/docs/02-design/features/agent-action-history.design.md
@@ -3,11 +3,12 @@
 > **Summary**: N100 Relay → FarmOS Postgres 를 SSE Bridge 로 잇고, FarmOS BE 에 원본 미러(30일) + 일/시간 요약 + 3 개 REST API 를 두며, 프론트 AIAgentPanel 에 요약 카드·더보기(cursor pagination)·상세 모달을 추가한다 (Option C — Pragmatic).
 >
 > **Project**: FarmOS - agent-action-history
-> **Version**: 0.1.0
+> **Version**: 0.2.0
 > **Author**: clover0309
-> **Date**: 2026-04-20
-> **Status**: Draft
+> **Date**: 2026-04-20 (Code Sync: 2026-04-23)
+> **Status**: **Production (implemented & verified)** — 2026-04-23 코드 기준 모든 Module 1~6 구현 완료. L1 26/26 PASS, L2 6/6 PASS, L3 2/3 PASS (§8.5 E2 SSE 실시간 테스트는 미구현, production 동작은 확인됨).
 > **Planning Doc**: [agent-action-history.plan.md](../../01-plan/features/agent-action-history.plan.md)
+> **Archive**: `docs/archive/2026-04/agent-action-history/` (plan/design/analysis/report 완료 스냅샷)
 
 ### Pipeline References
 
@@ -817,3 +818,4 @@ module-1 ──▶ module-2 ──▶ module-3
 |---------|------|---------|--------|
 | 0.1 | 2026-04-20 | Initial draft — Option C 선택, DDL/API/컴포넌트 확정, Module Map 6개 | clover0309 |
 | 0.2 | 2026-04-20 | §8 Test Plan 에 최종 실행 결과 추가 (L1 26/26, L2 6/6, L3 2/3) + E2 미구현 명시 | clover0309 |
+| 0.3 | 2026-04-23 | Code Sync — Status 를 Production 으로 상향. 구현체 파일 경로(§11.1) 는 코드와 1:1 매치 확인됨: `backend/app/services/ai_agent_bridge.py`, `backend/app/api/ai_agent.py`, `backend/app/models/ai_agent.py`, `frontend/src/modules/iot/AI*Panel.tsx` / `AIActivitySummaryCards.tsx` / `AIDecisionDetailModal.tsx`, `frontend/src/hooks/useAIAgent.ts`. 피처 플래그 `AI_AGENT_BRIDGE_ENABLED` 배포 절차는 `docs/backend-architecture.md §AI Agent Bridge Worker` 참조. SSE broadcast 불변식(persist → broadcast) 은 `docs/iot-ai-agent-implementation.md §13.2` 로 이관. | clover0309 |

--- a/docs/02-design/features/iot-manual-control.design.md
+++ b/docs/02-design/features/iot-manual-control.design.md
@@ -3,8 +3,9 @@
 > **Feature**: iot-manual-control
 > **Architecture**: Option C — Pragmatic Balance
 > **Plan Reference**: `docs/01-plan/features/iot-manual-control.plan.md`
-> **Date**: 2026-04-16
-> **Status**: Draft
+> **Date**: 2026-04-16 (Code Sync: 2026-04-23)
+> **Status**: **Production (Software-First 단계 완료)** — Relay `control_store.py` / `control_routes.py` / `main.py` 라우터 등록 + FE `ManualControlPanel.tsx` / `useManualControl.ts` / `useSensorData.ts` SSE control 이벤트 소비 구현 완료. ESP8266 펌웨어 폴링 루프 구현 완료 (`HARDWARE_BUTTONS_ENABLED=false` 상태로 빌드). 브레드보드 배선은 아직 미구성 — Phase 별 하드웨어 테스트(§8.2) 는 회로 구성 후 수행.
+> **Archive**: `docs/archive/2026-04/manual-control-onoff/` (plan/design/analysis/report 완료 스냅샷)
 
 ---
 
@@ -938,3 +939,4 @@ curl http://iot.lilpa.moe:9000/api/v1/control/state
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
 | 0.1 | 2026-04-16 | Initial draft — Option C (Pragmatic Balance) | clover0309 |
+| 0.2 | 2026-04-23 | Code Sync — Status 를 Production 으로 상향. Relay `control_store.py` 영속화(`control_state.json` 파일) 와 `control_routes.py` 5개 엔드포인트는 `iot-relay-server-plan.md §4.3` 에 공식 엔드포인트로 등록됨. FE 시뮬레이션 모드(`simulateButton` → `POST /control/report`) 동작 확인. ESP8266 폴링 루프는 `HARDWARE_BUTTONS_ENABLED` 컴파일 플래그로 비활성 상태 유지. | clover0309 |

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,5 +1,7 @@
 # FarmOS Backend Architecture
 
+<!-- Code Sync: 2026-04-23 -->
+
 ## 기술 스택
 
 | 항목 | 기술 | 버전 |
@@ -9,11 +11,14 @@
 | 웹 프레임워크 | FastAPI | 0.135.2 |
 | 설정 관리 | pydantic-settings | 2.13.1 |
 | ASGI 서버 | uvicorn | 0.42.0 |
-| 데이터 저장 (인증) | PostgreSQL 18 | asyncpg |
-| 데이터 저장 (IoT) | **PostgreSQL 18** (`iot_` 접두사 테이블) | asyncpg |
+| 데이터 저장 (인증 / 쇼핑몰 / AI 판단 미러) | PostgreSQL 18 | asyncpg |
+| IoT 센서·관수·알림 SSoT | **N100 Relay 전용 `iot-postgres` 컨테이너 (`iotdb`)** | Relay asyncpg |
+| Vector DB (리뷰 임베딩) | ChromaDB (LiteLLM → Voyage v3.5) | 컬렉션 `reviews_voyage_v35` |
+| SSE (임베딩/분석 진행률) | sse-starlette | `EventSourceResponse` |
 
-> 2026-04-20 IoT 저장소를 인메모리(`deque` / `list`)에서 PostgreSQL로 전환.
-> 사용자 인증 / IoT 센서 모두 PostgreSQL `farmos` DB에 영속 저장되며 접두사로 구분한다(`iot_*`, 인증 `users`, 쇼핑몰 `shop_*`).
+> **2026-04-21**: FarmOS 로컬 DB 의 `iot_sensor_readings` / `iot_sensor_alerts` / `iot_irrigation_events` 테이블과 `/api/v1/sensors*` · `/api/v1/irrigation/*` 엔드포인트는 **완전 제거**됐다. 아래 §IoT PostgreSQL 저장소 / §API 엔드포인트 / §자동 관개 트리거 / §데이터 흐름 섹션은 **레거시 기록**으로, 현재 IoT 센서 데이터는 전적으로 Relay (`iot-postgres`) 가 SSoT 다. 상세 이전 경로는 `iot-relay-server-plan.md` 참조.
+> **2026-04-20**: IoT 저장소를 인메모리(`deque` / `list`)에서 PostgreSQL로 전환 (Relay 측 패치 §iot-relay-server-postgres-patch.md).
+> 접두사 규칙: 인증 `users`, 쇼핑몰 `shop_*`, AI 판단 미러 `ai_agent_*` (30일 TTL), 리뷰 분석 `review_analyses` / `review_sentiments`.
 
 ---
 
@@ -49,9 +54,11 @@ backend/
 
 ---
 
-## IoT PostgreSQL 저장소 (`app/core/store.py`)
+## IoT PostgreSQL 저장소 (`app/core/store.py`) [LEGACY — 2026-04-21 제거됨]
 
-3개 테이블을 SQLAlchemy 2.0 async ORM으로 다룬다. 모델 정의는 `app/models/iot.py`.
+> **LEGACY 기록**: 아래 설명은 2026-04-20 ~ 2026-04-21 짧은 기간 동안 FarmOS 로컬 BE 가 IoT 테이블을 보관했을 때의 내용이다. 2026-04-21 이후 로컬 IoT 테이블·라우터·모델은 `backend/scripts/drop_iot_legacy_tables.sql` 로 완전 제거됐고, IoT 데이터는 N100 Relay `iot-postgres` 가 유일한 SSoT 다. 이 섹션은 히스토리 참조 용도로만 남긴다.
+
+3개 테이블을 SQLAlchemy 2.0 async ORM으로 다뤘다. 모델 정의는 `app/models/iot.py` (제거됨).
 
 | 테이블 | 주요 컬럼 | 설명 |
 |--------|----------|------|
@@ -86,22 +93,25 @@ Base URL: `/api/v1`
 }
 ```
 
-### Sensors
+### Sensors / Irrigation [LEGACY — 2026-04-21 제거됨]
 
-| 메서드 | 경로 | 설명 | 파라미터 |
-|--------|------|------|----------|
-| `POST` | `/sensors` | ESP8266 센서 데이터 수신 | body: `SensorDataIn` |
-| `GET` | `/sensors/latest` | 최신 센서 값 1건 | - |
-| `GET` | `/sensors/history` | 센서 데이터 목록 (시간순) | `limit` (1~2000, 기본 300) |
-| `GET` | `/sensors/alerts` | 알림 목록 | `resolved` (optional) |
-| `PATCH` | `/sensors/alerts/{alert_id}/resolve` | 알림 해결 처리 | - |
+> 이 엔드포인트들은 FarmOS BE 에서 제거됐다. 현재 FE(`useSensorData.ts`) 는 Relay (`http://iot.lilpa.moe:9000/api/v1/sensors*`, `/irrigation/*`) 를 직접 호출한다. 계약 명세는 `iot-relay-server-plan.md §4.1` 참조.
 
-### Irrigation
+### Review Analysis (`/reviews/*`, 2026-04-10 이후)
 
-| 메서드 | 경로 | 설명 | 파라미터 |
-|--------|------|------|----------|
-| `POST` | `/irrigation/trigger` | 수동 관개 밸브 제어 | body: `IrrigationTriggerIn` |
-| `GET` | `/irrigation/events` | 관개 이력 (최신순) | - |
+| 메서드 | 경로 | 설명 | 비고 |
+|--------|------|------|------|
+| `POST` | `/reviews/embed` | `shop_reviews` → ChromaDB 동기화 | `ReviewRAG.sync_from_db()` |
+| `GET` | `/reviews/embed/stream` | SSE 임베딩 진행률 | 2026-04-23 추가 |
+| `POST` | `/reviews/analyze` | LLM 3가지 분석 실행 | 감성/키워드/요약 |
+| `GET` | `/reviews/analyze/stream` | SSE 분석 진행률 + 중간 결과 | 층화 샘플링 (200, 최대 10000) |
+| `GET` | `/reviews/analysis` | 최신 분석 결과 | |
+| `POST` | `/reviews/search` | RAG 의미 검색 | |
+| `GET` | `/reviews/trends?period=weekly` | 트렌드/이상 탐지 | |
+| `GET` | `/reviews/report/pdf?analysis_id=N` | PDF 다운로드 | fpdf2 + 한글 폰트 |
+| `GET`/`PUT` | `/reviews/settings` | 자동 분석 설정 | 멀티테넌트/스케줄러 **Phase 2 연기** |
+
+모두 세션 인증. 상세: `docs/iot-review-analysis-implementation.md`.
 
 ### AI Agent (agent-action-history, 2026-04-20)
 
@@ -163,7 +173,15 @@ lifespan 기동 (AI_AGENT_BRIDGE_ENABLED=True 일 때만)
 
 ---
 
-## 데이터 흐름
+## 데이터 흐름 [LEGACY — 현재는 Relay 직결]
+
+> 아래 다이어그램은 2026-04-20 FarmOS 로컬 BE 가 IoT 중계를 겸했을 때의 흐름이다. 현재(2026-04-23)는 다음과 같다:
+>
+> ```
+> ESP8266 ── POST ──▶ N100 Relay (iot-postgres) ── SSE/GET ──▶ React 프론트
+>                               │
+>                               └── AI decision ── SSE/GET ──▶ FarmOS BE (ai_agent_bridge → ai_agent_decisions mirror) ──▶ FE
+> ```
 
 ```
 ┌─────────────────┐     HTTP POST       ┌──────────────────┐     GET        ┌──────────────┐
@@ -207,9 +225,11 @@ snake→camelCase 변환은 `store.py`의 `add_reading()`에서 저장 시점에
 
 ---
 
-## 자동 관개 트리거 로직
+## 자동 관개 트리거 로직 [LEGACY — Relay 로 이관]
 
-`POST /api/v1/sensors` 수신 시 자동 실행:
+> FarmOS `/sensors` POST 는 제거됐다. 자동 관개 규칙(`soil_moisture < 55%` → IrrigationEvent + Alert, `humidity > 90%` → Alert)은 현재 Relay `iot_relay_server/app/store.py` 에 이식되어 있다.
+
+레거시 동작 (FarmOS BE): `POST /api/v1/sensors` 수신 시 자동 실행:
 
 | 조건 | 동작 |
 |------|------|

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -14,15 +14,21 @@
 
 ## 저장소 구분
 
+<!-- Code Sync: 2026-04-23 -->
+
 | 영역 | 저장 방식 | 사유 |
 |------|----------|------|
-| 사용자 인증 | **PostgreSQL** | 영속 데이터 |
-| IoT 센서 | **PostgreSQL** (`iot_` 접두사 테이블) | 영속 저장, 서버 재시작 후에도 히스토리 유지 (2026-04-20 인메모리에서 전환) |
-| 쇼핑몰 | **PostgreSQL** (`shop_` 접두사 테이블) | FarmOS와 동일 DB 공유, 테이블명으로 구분 |
+| 사용자 인증 | **PostgreSQL** (`users`) | 영속 데이터 |
+| IoT 센서 / 관수 / 알림 | **N100 Relay 전용 `iot-postgres` 컨테이너 (`iotdb`)** | 2026-04-21 이후 FarmOS 로컬 DB 에서 제거. Relay 가 SSoT. |
+| AI 판단 (원본) | Relay `iotdb` (`iot_agent_decisions`) | Relay 가 canonical source |
+| AI 판단 (미러) | FarmOS `farmos` DB (`ai_agent_decisions` + `ai_agent_activity_daily/hourly`) | 최근 30일 mirror + 집계 |
+| 리뷰 분석 결과 | FarmOS `farmos` DB (`review_analyses`, `review_sentiments`) | 영속 |
+| 리뷰 임베딩 벡터 | **ChromaDB** (컬렉션 `reviews_voyage_v35`, 1024-dim) | PostgreSQL 밖, 디스크 persistent store |
+| 쇼핑몰 | **PostgreSQL** (`shop_` 접두사 테이블) | FarmOS와 동일 DB 공유 |
 
-> IoT 센서/관수/알림 데이터는 로컬 BE(`farmos` DB)와 N100 Relay(**전용 `iot-postgres` 컨테이너 / `iotdb` DB**)에 **동일한 스키마**로 저장된다.
-> 로컬 BE DB: 프론트엔드 대시보드 + AI Agent 조회 전용. N100 Relay DB: ESP8266 수신 전용.
-> N100 의 `iot-postgres` 는 기존 운영 중인 다른 Postgres 와 네트워크/볼륨/자격증명이 완전히 분리된 전용 인스턴스다.
+> **2026-04-21**: FarmOS `farmos` DB 의 `iot_*` 테이블은 `backend/scripts/drop_iot_legacy_tables.sql` 로 **완전 제거**됐다. 아래 §IoT 테이블 섹션은 **Relay 측 `iotdb` 의 스키마 레퍼런스**로만 유효하다 (Relay 는 같은 DDL 유지).
+> AI 판단 데이터는 Relay 가 원본, FarmOS 가 미러(30일 TTL) + 일/시간 요약을 Bridge Worker 로 동기화.
+> N100 `iot-postgres` 는 기존 운영 중인 다른 Postgres 와 네트워크/볼륨/자격증명이 완전히 분리된 전용 인스턴스다.
 
 ---
 
@@ -52,10 +58,12 @@
 
 ---
 
-## IoT 테이블 (`iot_` 접두사)
+## IoT 테이블 (`iot_` 접두사) — Relay `iotdb` 전용
 
-> 모델 파일: `backend/app/models/iot.py`
-> 저장소 모듈: `backend/app/core/store.py` (SQLAlchemy 2.0 async + asyncpg)
+<!-- Code Sync: 2026-04-23 — FarmOS 로컬 DB 에서 제거됨. Relay 만 보유. -->
+
+> **주의**: 2026-04-21 이후 FarmOS `farmos` DB 에는 `iot_*` 테이블이 존재하지 않는다. 아래 DDL 은 현재 **N100 Relay `iot-postgres` 컨테이너 / `iotdb` DB** 에만 적용된 상태다. 관련 소스는 `iot_relay_server/app/store.py` (asyncpg), DDL 원본은 `iot_relay_server/iot_init.sql` 또는 `docs/iot-relay-server-postgres-patch.md §1`.
+> 이전 모델 파일: `backend/app/models/iot.py` (삭제됨), `backend/app/core/store.py` (레거시 경로 제거됨).
 
 ### `iot_sensor_readings`
 
@@ -157,6 +165,48 @@ UPSERT 전략: Bridge 가 원본 INSERT 성공 시마다 `ON CONFLICT (day, cont
 > **데이터 정합성**: `ai_agent_decisions` (원본) 이 canonical source. daily/hourly 는 Bridge 가 장애로 누락된 경우 원본에서 재빌드 가능 (운영 스크립트는 추후 작성).
 >
 > **TTL**: `ai_agent_decisions` 는 `AI_AGENT_MIRROR_TTL_DAYS=30` (default). 야간 배치로 `DELETE WHERE created_at < now() - INTERVAL '30 days'` 수행 예정 (현재 수동 또는 Bridge 에 후속 구현).
+
+---
+
+## 리뷰 분석 테이블 (`review_analyses`, `review_sentiments`)
+
+<!-- Code Sync: 2026-04-23 -->
+
+> 모델: `backend/app/models/review_analysis.py`
+> Pydantic 스키마: `backend/app/schemas/review_analysis.py`
+> 생성: FastAPI 기동 시 `Base.metadata.create_all` 로 자동 생성.
+
+### `review_analyses` (분석 실행 기록)
+
+| 컬럼 | 타입 | NULL | 설명 |
+|------|------|:----:|------|
+| id | SERIAL | NO | PK |
+| analysis_type | VARCHAR(20) | NO | `manual` \| `batch` (현재 `batch` 미사용 — Phase 2 연기) |
+| target_scope | VARCHAR(50) | NO | `all` \| `product:{id}` \| `platform:{name}` |
+| review_count | INTEGER | NO | 분석 대상 리뷰 총 건수 (샘플링 전 전체) |
+| sentiment_summary | JSONB | YES | `{positive, negative, neutral, total}` |
+| keywords | JSONB | YES | `[{word, count, sentiment}]` |
+| summary | TEXT | YES | 3-part 요약 JSON 문자열 (`overall` / `positives` / `negatives` / `suggestions`) |
+| trends | JSONB | YES | 주간/이상 탐지 결과 |
+| anomalies | JSONB | YES | `[{type, week, message, severity}]` |
+| llm_provider | VARCHAR(30) | YES | `OllamaClient` / `OpenRouterClient` / `RemoteOllamaClient` |
+| llm_model | VARCHAR(50) | YES | `llama3`, `openai/gpt-4o-mini` 등 |
+| processing_time_ms | INTEGER | YES |  |
+| created_at | TIMESTAMPTZ | NO | `now()` default |
+
+### `review_sentiments` (개별 리뷰 감성 캐시)
+
+| 컬럼 | 타입 | NULL | 설명 |
+|------|------|:----:|------|
+| id | SERIAL | NO | PK |
+| review_id | VARCHAR(50) | NO | ChromaDB 리뷰 ID (외부 키 없음, 논리적 참조) |
+| sentiment | VARCHAR(10) | NO | `positive` \| `negative` \| `neutral` |
+| score | FLOAT | YES | 0.0 ~ 1.0 신뢰도 |
+| reason | TEXT | YES | LLM 판단 근거 |
+| keywords | JSONB | YES | 리뷰별 키워드 |
+| analyzed_at | TIMESTAMPTZ | NO | `now()` default |
+
+> ChromaDB 벡터는 별도 저장. 컬렉션: `reviews_voyage_v35` (1024-dim, LiteLLM → VoyageAI `voyage-3.5`). Migration history: §iot-review-analysis-implementation.md §2.1.
 
 ---
 

--- a/docs/iot-ai-agent-implementation.md
+++ b/docs/iot-ai-agent-implementation.md
@@ -2,6 +2,8 @@
 
 > **작성일**: 2026-04-07
 > **상태**: 구현 완료 (버그 수정 포함)
+>
+> **Code Sync 2026-04-23**: 이 문서는 초기 규칙+LLM JSON 판단 구조를 기록한다. 2026-04-14 Tool Calling 전환(§6 tools/ 패키지, §13 reasoning_trace) 이후 변경 사항은 본 문서에도 부분 반영되어 있으며, 상세한 전환 보고는 `docs/iot-ai-agent-tool-calling-report.md` 를 읽는다. FarmOS 측 판단 미러(`ai_agent_decisions`) 는 `docs/02-design/features/agent-action-history.design.md` 참고.
 
 ---
 
@@ -95,21 +97,35 @@ KY-018 LDR이 간헐적으로 0값을 반환하는 문제 대응:
 
 ### 릴레이 서버 (iot_relay_server/app/)
 
+<!-- Code Sync: 2026-04-23 — tools/ 패키지, control_store.py 추가 반영 -->
+
 | 파일 | 역할 |
 |------|------|
-| `config.py` | 설정 (AI_AGENT_MODEL, KMA 키 등) |
+| `config.py` | 설정 (AI_AGENT_MODEL=`gpt-5-mini`, KMA 키 등) |
 | `sensor_filter.py` | 센서 이상값 필터링 |
-| `weather_client.py` | 기상청 API 클라이언트 |
-| `ai_agent_prompts.py` | LLM 시스템/사용자 프롬프트 |
-| `ai_agent.py` | Agent 엔진 (규칙+LLM, 상태관리, 이력) |
-| `schemas.py` | CropProfileIn, OverrideIn 추가 |
-| `store.py` | 토양습도 추정 (기존) |
-| `main.py` | Agent 라우터 + 센서수신 시 Agent 호출 |
+| `weather_client.py` | 기상청 API 클라이언트 (+ mock 예보) |
+| `ai_agent_prompts.py` | Tool Use 시스템/사용자 프롬프트 |
+| `ai_agent.py` | Agent 엔진 (규칙 엔진 + LLM Tool Calling 루프, 상태관리, 이력, SSE broadcast) |
+| `tools/definitions.py` | **(신규)** 8개 Tool JSON Schema 정의 (읽기 4 + 제어 4) |
+| `tools/executor.py` | **(신규)** Tool 실행 디스패처 + 핸들러 |
+| `control_store.py` | **(신규)** 수동 제어 인메모리 상태 + 파일 영속화 (`control_state.json`) |
+| `control_routes.py` | **(신규)** `/api/v1/control/*` 5개 엔드포인트 |
+| `schemas.py` | CropProfileIn, OverrideIn, ControlCommandIn, ControlReportIn 등 |
+| `store.py` | 토양습도 추정 + `iot_sensor_readings/irrigation/alerts` asyncpg CRUD + SSE broadcast 공유 (`_broadcast`, `_sse_subscribers`) + `iot_agent_decisions` asyncpg CRUD (`add_agent_decision` 등) |
+| `main.py` | `sensors_router` + `ai_agent_router` + `control_router` 등록, asyncpg Pool lifespan |
 
 ### 로컬 백엔드 (backend/app/)
 
-릴레이 서버와 동일한 구조로 `core/` 하위에 배치.
-`api/ai_agent.py`는 JWT 인증 포함.
+> **2026-04-14 Tool Calling 전환**: 백엔드의 `core/ai_agent.py`·`core/ai_agent_prompts.py`·`api/ai_agent.py` **Agent 판단 로직**은 Relay 와의 중복 제거 차원에서 삭제되었다. 백엔드는 더 이상 LLM 을 직접 호출하지 않고, Relay 가 canonical source.
+>
+> **2026-04-20 agent-action-history**: 대신 백엔드는 Relay `ai_decision` 을 소비해 `ai_agent_decisions` 미러 테이블에 저장하는 **Bridge Worker** 와 **읽기 전용 API** 를 담당한다.
+
+| 레이어 | 파일 | 역할 |
+|--------|------|------|
+| Services | `backend/app/services/ai_agent_bridge.py` | Relay SSE 구독 + HTTP backfill + 멱등 UPSERT + daily/hourly 요약 |
+| Models | `backend/app/models/ai_agent.py` | `AiAgentDecision` / `AiAgentActivityDaily` / `AiAgentActivityHourly` |
+| API | `backend/app/api/ai_agent.py` | `/api/v1/ai-agent/activity/summary`, `/decisions`, `/decisions/{id}`, `/bridge/status` (세션 인증) |
+| Main | `backend/app/main.py` | `AI_AGENT_BRIDGE_ENABLED=True` 일 때 lifespan 에서 Bridge `asyncio.create_task` 로 start |
 
 ### 프론트엔드 (frontend/src/)
 
@@ -208,3 +224,48 @@ docker-compose up -d --build
 ```
 
 Docker 재빌드 시 새 파일(sensor_filter.py, weather_client.py, ai_agent.py 등)이 자동 포함됨.
+
+---
+
+## 13. reasoning_trace / tool_calls 정의 (2026-04-23 추가)
+
+<!-- Code Sync: 2026-04-23 -->
+
+Tool Calling 전환 이후 "reasoning trace" 라는 용어가 여러 장소(프롬프트, 모델, 프론트 UI) 에서 사용되므로 정의를 명확히 한다.
+
+### 13.1 저장되는 것 / 저장되지 않는 것
+
+| 항목 | 저장 위치 | 타입 | 저장 여부 |
+|------|-----------|------|:--------:|
+| 최종 `reason` 1~2문장 요약 | `iot_agent_decisions.reason` / `ai_agent_decisions.reason` | TEXT | ✅ |
+| Tool 호출 순서·인자·result | `iot_agent_decisions.tool_calls` / `ai_agent_decisions.tool_calls` | JSONB 배열 | ✅ |
+| 판단 시점 센서 스냅샷 | `sensor_snapshot` | JSONB | ✅ |
+| `action` (실제 제어 변경 payload) | `action` | JSONB | ✅ |
+| LLM 멀티턴 대화 히스토리 전체 (system/user/assistant turns) | — | — | ❌ 저장하지 않음 |
+| LLM raw completion (tokens/logprobs/stop_reason 등) | — | — | ❌ 저장하지 않음 |
+
+즉, **"reasoning_trace" 는 이 문서 맥락에서 `tool_calls` JSONB 배열을 가리킨다**. full LLM turn history 를 persist 하지 않는 이유는 (1) 토큰 수만큼 DB 비용이 선형 증가하고, (2) 30일 TTL(`AI_AGENT_MIRROR_TTL_DAYS`) 내에서 재구성 가치가 낮기 때문이다.
+
+### 13.2 SSE broadcast 순서 불변식
+
+```
+[LLM 완료] → [iot_agent_decisions INSERT (reason + tool_calls + sensor_snapshot)]
+           → [SSE broadcast("ai_decision", payload)]
+```
+
+- **persist 가 반드시 broadcast 보다 앞**에 있어야 한다.
+- 이유: FarmOS Bridge 는 `ai_agent_decisions` 테이블에 `ON CONFLICT (id) DO NOTHING` 으로 UPSERT 한다. broadcast 가 먼저 도착해 Bridge 가 insert 하더라도, Relay 가 장애로 재시작하면 Bridge 의 backfill 호출(`GET /ai-agent/decisions?since=...`) 이 Relay DB 를 기준으로 하기 때문에 Relay persist 가 누락되면 `tool_calls` 가 영구 유실된다.
+- 불변식 위반 예: `broadcast → (장애) → persist 미실행` 시, FarmOS 측 row 는 존재하지만 tool_calls 가 `[]` 상태가 될 수 있다.
+
+이 규칙은 `iot-relay-server-postgres-patch.md` §10.4 와 `docs/02-design/features/agent-action-history.design.md` §2.2 의 Happy Path 를 구체화한 것이다.
+
+### 13.3 프론트엔드 소비
+
+- `AIDecisionDetailModal.tsx` 는 `tool_calls` 배열을 순번·도구명·arguments·result.success 로 렌더.
+- `AIAgentPanel.tsx` 의 row 는 요약(`reason` 1줄 + SourceBadge `rule`/`llm`/`tool`/`manual`) 만 표시하고 트레이스 전체는 모달로 이동.
+- `useSensorData.ts` SSE `ai_decision` 수신 → `_aiDecisionHandlers` 체인 → `useAIAgent` 훅이 목록 최상단에 prepend 및 `/activity/summary` 숫자 증가.
+
+### 13.4 운영 관찰 포인트
+
+- `/api/v1/ai-agent/bridge/status` 의 `last_event_at` 이 5분 이상 정체되면 SSE 연결 단절 또는 LLM 호출 중단 의심.
+- Relay `iot_agent_decisions` 와 FarmOS `ai_agent_decisions` 의 건수 차이가 backfill TTL(`AI_AGENT_MIRROR_TTL_DAYS=30`) 이내에서 `±1` 를 초과하면 불변식 위반 징후.

--- a/docs/iot-ai-agent-tool-calling-report.md
+++ b/docs/iot-ai-agent-tool-calling-report.md
@@ -181,9 +181,28 @@ ESP8266 (DHT11 + CdS, 30초 간격)
 
 ---
 
-## 8. 향후 계획
+## 8. 향후 계획 / 후속 작업 결과
 
-- [ ] LangChain 래핑 레이어 추가 (팀원 협업용)
-- [ ] 기상청 단기예보 API 연동 (현재 mock 예보)
-- [ ] 제어 이력 PostgreSQL 영속화 (현재 인메모리)
-- [ ] 프론트엔드: 수동 오버라이드 UI 완성 (현재 view-only)
+<!-- Code Sync: 2026-04-23 -->
+
+### 8.1 완료 (2026-04-23 기준 production)
+
+| 항목 | 완료 시점 | 결과 / 관련 문서 |
+|------|-----------|-----------------|
+| **제어 이력 PostgreSQL 영속화** | 2026-04-20 | Relay `iot_agent_decisions` 테이블 + `add_agent_decision()` · `list_agent_decisions()` · `get_agent_decision()` (`iot_relay_server/app/store.py`, DDL: `iot-relay-server-postgres-patch.md §10.1`). FarmOS 는 30일 미러(`ai_agent_decisions`) + 일/시간 요약 유지. |
+| **FarmOS 연동 (SSE Bridge)** | 2026-04-20 | `backend/app/services/ai_agent_bridge.py` — SSE 상시 구독 + HTTP backfill + exponential backoff + 멱등 UPSERT. `AI_AGENT_BRIDGE_ENABLED` 플래그로 on/off. `agent-action-history` feature 로 별도 Design/Plan/Analysis/Report 보유. |
+| **프론트엔드: 수동 제어 UI** | 2026-04-16 | `iot-manual-control` feature — `ManualControlPanel.tsx` + `useManualControl.ts` + `control_store.py` + `control_routes.py`. 시뮬레이션 모드(`POST /control/report` 직접 호출) 로 하드웨어 없이도 양방향 흐름 검증 가능. 상세는 `docs/02-design/features/iot-manual-control.design.md`. |
+| **판단 이력 FE 모달** | 2026-04-20 | `AIDecisionDetailModal.tsx` + `AIActivitySummaryCards.tsx` + `useAIAgent` 확장 (2-base 패턴: Relay 토글 + FarmOS 결정 조회). cursor 기반 더보기, row 클릭 시 tool_calls·sensor_snapshot 표시. |
+
+### 8.2 미완료 / 유보
+
+| 항목 | 상태 | 사유 |
+|------|:----:|------|
+| LangChain 래핑 레이어 | ⏸ 보류 | 현재 OpenAI SDK 직접 호출로 충분. 팀 규모 확대 전까지 YAGNI. |
+| 기상청 단기예보 API 연동 | ⏸ 보류 | KMA 초단기실황은 연동됨 (`weather_client.py`). 단기예보는 현재 mock 보충으로 판단 품질 저하 체감되면 재검토. |
+
+### 8.3 후속 feature (별도 PDCA 사이클)
+
+- `agent-action-history` (2026-04-20, 아카이브 완료) — 판단 영속화 + FE 상세 모달
+- `iot-manual-control` (2026-04-16, 아카이브 완료) — 양방향 제어 + 시뮬레이션 모드
+- `esp8266-led-sync` (2026-04-*, 아카이브 완료) — 하드웨어 LED 동기화

--- a/docs/iot-dashboard-improvements.md
+++ b/docs/iot-dashboard-improvements.md
@@ -101,11 +101,93 @@ clamp(20, 85)
 
 ---
 
+## 5. AI Agent Panel + SSE 이벤트 소비 (2026-04-23 추가)
+
+<!-- Code Sync: 2026-04-23 -->
+
+2026-04-07 이후 IoT 대시보드는 센서 표시 기능을 넘어, AI Agent 판단 이력·요약·상세 모달과 수동 제어 패널까지 통합된 상태다. 아래는 현재 production 코드(2026-04-23 기준) 의 프론트엔드 구조다.
+
+### 5.1 컴포넌트 트리 (IoTDashboardPage)
+
+```
+IoTDashboardPage.tsx
+├── SensorCards            (기존)
+├── IrrigationHistoryList + IrrigationModal (기존 §1~2)
+├── SensorAlertList        (기존 §1)
+├── ManualControlPanel     (iot-manual-control feature)
+│   ├── ControlCard × 4    (환기/관수/조명/차광)
+│   └── SimulationBar      (시뮬레이션 모드)
+└── AIAgentPanel           (Tool Calling 전환 후)
+    ├── AIActivitySummaryCards   (오늘/7일/30일 탭 집계)
+    ├── 4대 제어 상태 카드
+    ├── 최근 판단 목록            (row 클릭 → DetailModal)
+    └── AIDecisionDetailModal    (tool_calls, sensor_snapshot 표시)
+```
+
+### 5.2 SSE 단일 연결, 다중 이벤트 소비
+
+`useSensorData.ts` 는 단일 EventSource(`/api/v1/sensors/stream`) 를 유지하며, 이벤트 타입별로 별도 핸들러 레지스트리를 두고 여러 훅/컴포넌트가 중복 연결 없이 구독한다.
+
+| 이벤트 | 핸들러 레지스트리 | 소비 훅/컴포넌트 |
+|--------|------------------|------------------|
+| `sensor` | 내부 state 업데이트 | SensorCards |
+| `alert` | 내부 state 업데이트 | SensorAlertList |
+| `irrigation` | 내부 state 업데이트 | IrrigationHistoryList |
+| `control` | `_controlHandlers` | `useManualControl.handleControlEvent` → ManualControlPanel |
+| `ai_decision` | `_aiDecisionHandlers` | `useAIAgent` → AIAgentPanel (prepend + 요약 숫자 증가) |
+
+실패 감지는 기존 5회 연속 실패 규칙(§4)을 유지하며, EventSource 는 자동 재연결.
+
+### 5.3 useAIAgent 2-base 패턴
+
+`useAIAgent` 는 두 개의 API base 를 동시에 사용한다.
+
+| Base | 용도 | 호출 대상 |
+|------|------|----------|
+| Relay `VITE_IOT_API_URL` (예: `http://iot.lilpa.moe:9000/api/v1`) | Agent ON/OFF, 작물 프로필, 수동 오버라이드 | `/ai-agent/toggle`, `/ai-agent/crop-profile`, `/ai-agent/override` |
+| FarmOS `VITE_API_BASE` (예: `/api/v1`) | 판단 이력 조회 (미러) + 요약 | `/ai-agent/activity/summary`, `/ai-agent/decisions?cursor=...`, `/ai-agent/decisions/{id}` |
+
+이력 조회를 FarmOS BE 로 돌리는 이유는 FarmOS Bridge Worker 가 최근 30일 미러 + 집계 테이블을 들고 있어 Relay 재시작과 무관하게 이력이 유지되기 때문이다. `ai_agent_decisions` row 의 `id` 는 Relay UUID 를 그대로 PK 로 재사용하므로 Detail Modal 의 "원본 id" 도 동일하다.
+
+### 5.4 SSE `ai_decision` 소비 규칙
+
+- 수신 payload 는 `AIDecision` 전체 shape (id/reason/action/tool_calls/sensor_snapshot/duration_ms).
+- **persist → broadcast** 순서가 Relay 측에서 보장되므로 (`iot-ai-agent-implementation.md §13.2`), FE 는 FarmOS Bridge 의 eventual consistency 에 의존할 필요 없이 payload 를 그대로 prepend 할 수 있다.
+- 요약 카드는 현재 탭이 `today` 일 때만 증분 계산(total + by_*) 한다. 다른 탭은 탭 전환 시 `/activity/summary?range=...` 를 재조회한다.
+
+### 5.5 수정 / 신규 파일 (2026-04-16 ~ 2026-04-20)
+
+| 파일 | 상태 | 책임 |
+|------|:----:|------|
+| `frontend/src/modules/iot/AIAgentPanel.tsx` | ✏ MODIFY | row 전체 클릭 → DetailModal, 기존 "도구 호출 N건" 버튼 제거 |
+| `frontend/src/modules/iot/AIActivitySummaryCards.tsx` | ★ NEW | 오늘/7일/30일 탭 + 4카드 (total / top1 ctype / top1 source / avg duration) |
+| `frontend/src/modules/iot/AIDecisionDetailModal.tsx` | ★ NEW | reason / action / sensor_snapshot / tool_calls (N) 렌더 + Copy 버튼 |
+| `frontend/src/modules/iot/ManualControlPanel.tsx` | ★ NEW | 4종 제어 카드 + 시뮬레이션 모드 토글 |
+| `frontend/src/hooks/useAIAgent.ts` | ✏ MODIFY | 2-base 패턴 + `fetchMore(cursor)` `fetchDetail(id)` `fetchSummary(range)` + SSE prepend |
+| `frontend/src/hooks/useManualControl.ts` | ★ NEW | 제어 상태 관리 + SSE control 이벤트 수신 + 시뮬레이션 버튼 |
+| `frontend/src/hooks/useSensorData.ts` | ✏ MODIFY | `addEventListener('control')`, `addEventListener('ai_decision')` + 핸들러 레지스트리 |
+| `frontend/src/types/index.ts` | ✏ MODIFY | `AIDecision` id 필수화, `sensor_snapshot?`·`duration_ms?`·`created_at?` 추가, `ControlEvent`/`ManualControlState` 등 |
+
+---
+
 ## 수정 파일 전체 목록
 
 | 파일 | 변경 항목 |
 |------|----------|
-| `frontend/src/modules/iot/IoTDashboardPage.tsx` | 더보기, 모달+그래프 |
-| `frontend/src/hooks/useSensorData.ts` | 연결 끊김 판정 5회 연속 실패 |
-| `iot_relay_server/app/store.py` | 토양 습도 추정 로직 (서비스) |
+| `frontend/src/modules/iot/IoTDashboardPage.tsx` | 더보기, 모달+그래프, ManualControlPanel 통합 |
+| `frontend/src/hooks/useSensorData.ts` | 5회 연속 실패 연결 끊김 + control/ai_decision SSE 핸들러 |
+| `frontend/src/modules/iot/AIAgentPanel.tsx` | row 클릭 상세 모달, 요약 카드 슬롯 |
+| `frontend/src/modules/iot/AIActivitySummaryCards.tsx` | **신규** — 오늘/7일/30일 탭 요약 |
+| `frontend/src/modules/iot/AIDecisionDetailModal.tsx` | **신규** — tool_calls trace 상세 |
+| `frontend/src/modules/iot/ManualControlPanel.tsx` | **신규** — 수동 제어 UI + 시뮬레이션 |
+| `frontend/src/hooks/useAIAgent.ts` | 2-base 패턴 + pagination + SSE prepend |
+| `frontend/src/hooks/useManualControl.ts` | **신규** — 제어 상태 + SSE control 수신 |
+| `iot_relay_server/app/store.py` | 토양 습도 추정 로직 (서비스) + `add_agent_decision` · `list_agent_decisions` |
+| `iot_relay_server/app/control_store.py` | **신규** — 제어 상태 인메모리 + 파일 영속화 |
+| `iot_relay_server/app/control_routes.py` | **신규** — 5개 제어 엔드포인트 |
+| `iot_relay_server/app/tools/definitions.py` | **신규** — 8개 Tool JSON Schema |
+| `iot_relay_server/app/tools/executor.py` | **신규** — Tool 실행 디스패처 |
+| `backend/app/services/ai_agent_bridge.py` | **신규** — SSE + backfill + 멱등 UPSERT + daily/hourly |
+| `backend/app/api/ai_agent.py` | **신규** — 미러 읽기 API (JWT 인증) |
+| `backend/app/models/ai_agent.py` | **신규** — 3 테이블 ORM |
 | `backend/app/core/store.py` | 토양 습도 추정 로직 (로컬 동기화) |

--- a/docs/iot-relay-server-plan.md
+++ b/docs/iot-relay-server-plan.md
@@ -1,6 +1,7 @@
 # IoT 중계 서버 구축 계획 (N100 서버)
 
 > **업데이트 이력**
+> - 2026-04-23 (Code Sync): Relay 는 센서·관수·알림 외에 **AI Agent** (§4.2) 및 **수동 제어** (§4.3) 엔드포인트, **SSE 스트림** (§4.4) 를 제공하는 상태로 통합되어 있다. 본 섹션 추가는 현재 production 코드와 문서 정합을 위한 것이며, 엔드포인트 목록/SSE 이벤트/AI 판단 영속화 스키마는 §10 (postgres-patch) 및 `iot-ai-agent-tool-calling-report.md` 와 함께 읽는다.
 > - 2026-04-21: FarmOS 로컬 DB의 레거시 IoT 테이블(`iot_sensor_readings` / `iot_sensor_alerts` / `iot_irrigation_events`)과
 >   관련 엔드포인트(`/api/v1/sensors*`, `/api/v1/irrigation/*`) **완전 제거**. IoT 센서·알림·관수 데이터의
 >   SSoT는 이제 Relay 전용 `iotdb` 단일 저장소이며, FarmOS DB는 AI 판단 미러(`ai_agent_decisions` 외 2개)만 보관한다.
@@ -92,6 +93,10 @@ iot_relay_server/
 
 ## 4. 주요 엔드포인트
 
+<!-- Code Sync: 2026-04-23 -->
+
+### 4.1 센서 / 관수 / 알림 (ESP8266 및 FE 공개)
+
 | Method | Path | 인증 | 용도 |
 |--------|------|------|------|
 | POST | `/api/v1/sensors` | X-API-Key | ESP8266 데이터 수신 → `iot_sensor_readings` insert |
@@ -106,6 +111,61 @@ iot_relay_server/
 > GET 엔드포인트는 JWT 인증 없이 공개 (시연용).
 > POST /sensors만 API Key로 보호.
 > 응답 JSON shape(camelCase)은 기존 인메모리 버전과 동일 → 프론트 회귀 없음.
+
+### 4.2 AI Agent (2026-04-14 Tool Calling 전환 이후)
+
+상세 구현 기록은 `docs/iot-ai-agent-tool-calling-report.md`, Relay 측 DDL·핸들러·영속화는 `§10` 참고.
+
+| Method | Path | 인증 | 용도 |
+|--------|------|------|------|
+| GET | `/api/v1/ai-agent/status` | 없음 | Agent 상태 + 현재 제어값 + 최신 판단 스냅샷 |
+| GET | `/api/v1/ai-agent/decisions` | 없음 | 판단 이력 (cursor pagination: `cursor`, `limit`, `control_type`, `source`, `priority`, `since`). FarmOS Bridge 가 backfill 시 호출하는 계약 |
+| GET | `/api/v1/ai-agent/decisions/{id}` | 없음 | 판단 단건 상세 (DetailModal 소비) |
+| POST | `/api/v1/ai-agent/toggle` | 없음 | Agent ON/OFF 전환 |
+| GET | `/api/v1/ai-agent/crop-profile` | 없음 | 작물 프로필 + 프리셋 |
+| PUT | `/api/v1/ai-agent/crop-profile` | 없음 | 작물 프로필 수정 |
+| POST | `/api/v1/ai-agent/override` | 없음 | 수동 오버라이드 |
+| POST | `/api/v1/ai-agent/test-trigger` | 없음 | 디버그용 수동 트리거 |
+
+> AI Agent 판단 영속화 테이블(`iot_agent_decisions`) 및 판단 생성 훅은 §10 에 규정. 판단 `id` 는 Relay 에서 UUID 로 생성되고, FarmOS Bridge 는 이 `id` 를 PK 로 그대로 재사용한다 — At-Least-Once with Idempotent Upsert (`ON CONFLICT (id) DO NOTHING`).
+
+### 4.3 수동 제어 (iot-manual-control)
+
+상세 설계는 `docs/02-design/features/iot-manual-control.design.md` 참조. 제어 상태는 `control_store.py` 의 인메모리 + 파일 영속화(`control_state.json`) 로 관리된다.
+
+| Method | Path | 인증 | 용도 |
+|--------|------|------|------|
+| POST | `/api/v1/control` | 없음 | 프론트엔드 제어 명령 전송 (ventilation/irrigation/lighting/shading) |
+| GET | `/api/v1/control/state` | 없음 | 현재 제어 상태 조회 (4종 전체) |
+| GET | `/api/v1/control/commands` | X-API-Key | ESP8266 대기 명령 폴링 |
+| POST | `/api/v1/control/report` | X-API-Key | ESP8266 버튼/LED 상태 보고 (source="button") |
+| POST | `/api/v1/control/ack` | X-API-Key | ESP8266 명령 수신 확인 (큐 클리어) |
+
+### 4.4 SSE 스트림
+
+단일 SSE 엔드포인트 `GET /api/v1/sensors/stream` 이 여러 이벤트 타입을 발행한다. 프론트엔드(`frontend/src/hooks/useSensorData.ts`) 는 이 단일 연결을 재사용해 센서·관수·알림·제어·AI 판단을 모두 수신한다.
+
+| Event | Payload (요약) | 발행 시점 | 소비 컴포넌트 |
+|-------|---------------|----------|---------------|
+| `sensor` | 최신 reading (camelCase) | `POST /sensors` 수신 후 store insert 완료 시 | 센서 카드 / 그래프 |
+| `alert` | SensorAlert row | 임계치 초과로 alert insert 시 | 알림 리스트 |
+| `irrigation` | IrrigationEvent row | 관개 이벤트 insert 시 | 관수 이력 |
+| `control` | `{control_type, state, source, timestamp}` | `POST /control` 또는 `POST /control/report` 후 | ManualControlPanel |
+| `ai_decision` | `AIDecision` (id/reason/action/tool_calls/sensor_snapshot/duration_ms) | AI Engine 판단 완료 **+ DB insert 완료 후** | AIAgentPanel, FarmOS Bridge Worker |
+
+**중요한 순서 불변식 (§10.4 와 `iot-ai-agent-implementation.md` §13 에도 기술)**:
+
+```
+[판단 생성] → [iot_agent_decisions INSERT] → [SSE broadcast("ai_decision")]
+```
+
+SSE 가 persist 보다 먼저 나가면 FarmOS Bridge 의 `ON CONFLICT (id) DO NOTHING` UPSERT 는 성공하지만, Relay 재기동 시 backfill 대상이 영속 데이터에서 누락되어 `tool_calls` 트레이스가 영구 손실될 수 있다.
+
+### 4.5 헬스체크
+
+| Method | Path | 용도 |
+|--------|------|------|
+| GET | `/health` | `{storage, readings_count, irrigation_events_count, alerts_count}` 반환 |
 
 ---
 

--- a/docs/iot-relay-server-postgres-patch.md
+++ b/docs/iot-relay-server-postgres-patch.md
@@ -1,9 +1,11 @@
 # IoT Relay Server — PostgreSQL 전환 패치 스펙 (전용 컨테이너 분리)
 
 > **목적**: N100의 `iot_relay_server/` 를 인메모리에서 **전용 PostgreSQL 컨테이너**로 전환.
-> **적용**: 사용자가 N100 서버에서 직접 적용 (본 레포에는 Relay 코드가 존재하지 않음).
+> **적용**: 사용자가 N100 서버에서 직접 적용. 현재 리포는 `iot_relay_server/` 를 **루트 수준에서 포함**하고 있어 본 문서의 DDL/`app/store.py`/`app/main.py` 패치 구조와 1:1 매치됨.
 > **설계 결정 (2026-04-20)**: 기존 운영 중인 PostgreSQL 과 **격리된 전용 컨테이너** 운영.
 >   → 30초 주기 INSERT 워크로드가 기존 DB 성능에 영향을 주지 않음 + 독립 백업/업그레이드/리셋 가능.
+>
+> **Code Sync 2026-04-23 (Verification)**: §1 DDL (3 테이블 + `iot_agent_decisions` §10.1) 은 현재 Relay `iot_relay_server/iot_init.sql` 과 `app/store.py` asyncpg 쿼리에 그대로 적용되어 있음. §10.4 persist-before-broadcast 불변식은 `iot-ai-agent-implementation.md §13.2` 에 재정의되어 운영 규칙으로 격상됨. §10.8 asyncpg `AmbiguousParameterError` 대응(`CAST(:src AS text)`) 은 `backend/app/services/ai_agent_bridge.py` `_bump_daily` / `_bump_hourly` 에 반영 완료. 본 문서는 **현행 구조와 일치**하며 추가 수정이 필요하지 않다.
 
 ## 0. 아키텍처 (전용 컨테이너)
 

--- a/docs/iot-review-analysis-implementation.md
+++ b/docs/iot-review-analysis-implementation.md
@@ -2,8 +2,10 @@
 
 > **작성일**: 2026-04-10
 > **작성자**: clover0309
-> **PDCA Match Rate**: 96%
+> **PDCA Match Rate (초기)**: 96%
 > **상태**: 구현 완료 (아카이브 완료)
+>
+> **Code Sync 2026-04-23**: 이후 임베딩 파이프라인이 ChromaDB 내장(all-MiniLM-L6-v2) → Ollama(`nomic-embed-text`, BGE-M3) → **LiteLLM 프록시 + VoyageAI `voyage-3.5` (1024-dim)** 로 두 차례 마이그레이션됐다. 수동 분석에 SSE 스트리밍(`/embed/stream`, `/analyze/stream`) 이 추가됐고, 멀티테넌트 필터와 자동 배치 스케줄러는 **미구현 — Phase 2 연기** 상태다. 아래 섹션은 2026-04-23 기준 production 코드 상태를 반영한다.
 
 ---
 
@@ -16,24 +18,39 @@ LLM으로 감성분석/키워드추출/요약을 수행한다.
 ### 핵심 특징
 
 - **RAG 직접 구현**: LangChain 없이 ChromaDB + LLM 직접 연동
-- **LLM 추상화**: .env 설정만으로 Ollama(로컬) / OpenRouter(클라우드) / RunPod(원격) 전환
+- **생성 LLM 추상화**: .env 설정만으로 Ollama(로컬) / OpenRouter(클라우드) / RunPod(원격) 전환 (분석용 LLM)
+- **임베딩은 LiteLLM 프록시 경유 (Voyage v3.5, 2026-04-23 기준)**: 단순한 HTTP 포워딩으로 N100 부하 0, 모델 교체는 `.env` 의 `EMBED_MODEL` / `EMBED_DIM` 로 제어. 차원 변경 시 `COLLECTION_NAME` 변경 + 전체 재임베딩.
 - **1회 LLM 호출 = 3가지 분석**: 감성분석 + 키워드추출 + 요약을 단일 프롬프트로 동시 처리
-- **비용 최소화**: ChromaDB 내장 임베딩(비용 0원) + 배치 처리로 LLM 호출 횟수 최소화
+- **비용 최소화**: LiteLLM 임베딩은 배치 64 단위 + Voyage v3.5 단가 절감, 분석 LLM 은 배치 처리로 호출 횟수 최소화
+- **수동 트리거 전용 (2026-04-23)**: UI 버튼으로만 분석 실행. SSE 로 진행률 스트리밍. 자동 배치는 Phase 2 연기.
 
 ---
 
 ## 2. 기술 스택
 
+<!-- Code Sync: 2026-04-23 — 임베딩 파이프라인 마이그레이션 반영 -->
+
 | 구분 | 기술 | 비고 |
 |------|------|------|
-| 벡터DB | ChromaDB 1.5.5 | 내장 임베딩 모델 (all-MiniLM-L6-v2) |
-| LLM (개발) | Ollama (llama3) | 로컬 실행, 비용 0원 |
-| LLM (배포 A) | OpenRouter API | GPU 없는 서버용 |
-| LLM (배포 B) | Ollama on RunPod | GPU 서버 원격 실행 |
-| 백엔드 | FastAPI + SQLAlchemy (asyncpg) | 기존 FarmOS 스택 |
+| 벡터DB | ChromaDB | 컬렉션명 `reviews_voyage_v35` (1024-dim). 이전: `reviews_llama`(384-dim, 폐기), `reviews_bge_m3`(1024-dim, 중간 단계). |
+| 임베딩 | **LiteLLM 프록시 → VoyageAI `voyage-3.5`** (1024-dim) | `review_rag.py:LiteLLMEmbeddingFunction`. `.env`: `LITELLM_URL`, `LITELLM_API_KEY`, `EMBED_MODEL=voyage-3.5`, `EMBED_DIM=1024`. 배치 64. N100 위 LiteLLM 은 포워딩만 → CPU 부하 0. |
+| 분석 LLM (개발) | Ollama (llama3) | 로컬 실행, 비용 0원 |
+| 분석 LLM (배포 A) | OpenRouter API | GPU 없는 서버용 |
+| 분석 LLM (배포 B) | Ollama on RunPod | GPU 서버 원격 실행 |
+| 백엔드 | FastAPI + SQLAlchemy (asyncpg) + sse-starlette | 기존 FarmOS 스택 (SSE 스트리밍용 `sse-starlette.EventSourceResponse` 추가) |
 | 프론트엔드 | React + Vite + Recharts | 기존 FarmOS 스택 |
 | PDF 생성 | fpdf2 2.8.0 | 한글 폰트 지원 (맑은 고딕) |
 | 트렌드 분석 | Python statistics (내장) | 이동평균 + 표준편차 기반 이상 탐지 |
+
+### 2.1 임베딩 파이프라인 마이그레이션 이력
+
+| 시기 | 모델 | 차원 | 컬렉션 | 비고 |
+|------|------|:----:|--------|------|
+| 2026-04-10 ~ | ChromaDB 내장 `all-MiniLM-L6-v2` | 384 | `reviews_llama` | 영어 중심 모델로 한국어 유사도 부정확 → 교체 결정 |
+| 중간 단계 | Ollama `nomic-embed-text` / BGE-M3 (1024) | 1024 | `reviews_bge_m3` | 한국어 품질은 나아졌으나 N100 위 로컬 임베딩 CPU 부하 과다 |
+| **2026-04-23 현재** | **LiteLLM → VoyageAI `voyage-3.5`** | **1024** | **`reviews_voyage_v35`** | 외부 프록시, N100 부하 0. 컷오버 절차 runbook 참조. |
+
+> 컷오버 절차 및 구(舊) 컬렉션 정리 방법: `docs/runbooks/review-embedding-migration.md` (파일명 기준). `review_rag.py:55-59` Migration note 주석 참조.
 
 ---
 
@@ -69,25 +86,33 @@ LLM으로 감성분석/키워드추출/요약을 수행한다.
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 RAG 파이프라인
+### 3.2 RAG 파이프라인 (2026-04-23)
 
 ```
-[저장] 리뷰 텍스트 → ChromaDB.add() → 내장 임베딩 → 벡터 저장 (비용 0원)
-[검색] 자연어 질의 → ChromaDB.query() → 코사인 유사도 → 상위 N개 반환
-[분석] 검색된 리뷰 → LLM 1회 호출 → { 감성, 키워드, 요약 } JSON 반환
-[탐지] 분석 결과 → 이동평균 + 표준편차 → 이상 탐지 (LLM 불필요)
+[저장] DB(shop_reviews) → ReviewRAG.sync_from_db()
+         → LiteLLMEmbeddingFunction (HTTP → VoyageAI voyage-3.5)
+         → ChromaDB reviews_voyage_v35 (1024-dim)
+[검색] 자연어 질의 → 동일 임베딩 함수 → ChromaDB.query() → 코사인 유사도 → 상위 N
+[분석] 검색 or 층화샘플링(stratified by rating) → ReviewAnalyzer.analyze_batch()
+         → 분석용 LLM 1회 호출 → { 감성, 키워드, 요약 } JSON 반환
+[탐지] 분석 결과 → TrendDetector (이동평균 + 표준편차) → 이상 탐지 (LLM 불필요)
+[저장] review_analyses + review_sentiments INSERT
 ```
 
-### 3.3 LLM 추상화
+**샘플링 전략 (`review_analysis.py:_stratified_sample`)**: 전체 N 건 중 `sample_size` 건을 `rating` 분포를 유지하면서 추출 (예: 전체 5점이 60% 면 샘플도 60%). 기본 200, 최대 10,000 건. 분석 LLM 비용 선형성 확보.
+
+### 3.3 생성 LLM 추상화
 
 ```
 .env: LLM_PROVIDER=ollama|openrouter|ollama_remote
 
-get_llm_client()  ← 팩토리 함수
+get_llm_client()  ← 팩토리 함수 (core/llm_client_base.py)
   ├─ OllamaClient        (로컬, http://localhost:11434)
   ├─ OpenRouterClient     (클라우드, https://openrouter.ai/api/v1)
   └─ RemoteOllamaClient   (RunPod, OllamaClient 상속)
 ```
+
+> 분석용 LLM 만 이 추상화를 쓴다. 임베딩은 별도로 `LiteLLMEmbeddingFunction` 하나로 고정 — 차원 일관성이 ChromaDB 컬렉션 전체와 결합되므로 provider 를 런타임에 바꾸지 않는다 (§2.1 마이그레이션 이력 참조).
 
 ---
 
@@ -145,18 +170,37 @@ REVIEW_ANALYSIS_MAX_RETRIES=2
 
 ## 5. API 엔드포인트
 
-모든 엔드포인트는 JWT 인증(`farmos_token` 쿠키) 필요.
+<!-- Code Sync: 2026-04-23 -->
+
+모든 엔드포인트는 JWT 인증(`farmos_token` 쿠키, `Depends(get_current_user)`) 필요. 라우터 prefix: `/api/v1/reviews`.
 
 | Method | Endpoint | 설명 |
 |--------|----------|------|
-| POST | `/api/v1/reviews/embed` | Mock 리뷰 50건을 ChromaDB에 임베딩 저장 |
-| POST | `/api/v1/reviews/analyze` | LLM 감성분석 + 키워드 + 요약 실행 |
-| GET | `/api/v1/reviews/analysis` | 최신 분석 결과 조회 |
-| POST | `/api/v1/reviews/search` | RAG 의미 검색 (자연어 → 유사 리뷰) |
-| GET | `/api/v1/reviews/trends?period=weekly` | 트렌드/이상 탐지 데이터 |
-| GET | `/api/v1/reviews/report/pdf?analysis_id=N` | PDF 리포트 다운로드 |
-| GET | `/api/v1/reviews/settings` | 자동 분석 설정 조회 |
-| PUT | `/api/v1/reviews/settings` | 자동 분석 설정 변경 |
+| POST | `/embed` | `shop_reviews` 테이블에서 DB 동기화하여 ChromaDB에 임베딩 저장 (`sync_from_db`) |
+| **GET** | **`/embed/stream`** | **(2026-04-23 추가)** SSE 로 `sync_from_db_chunked` 진행률(청크 100건) 스트리밍 |
+| POST | `/analyze` | LLM 감성분석 + 키워드 + 요약 일괄 실행 |
+| **GET** | **`/analyze/stream`** | **(2026-04-23 추가)** SSE 로 분석 진행률 + 중간 결과 스트리밍. `batch_size` (5~100), `sample_size` (50~10000, 기본 200, 층화 샘플링) |
+| GET | `/analysis` | 최신 분석 결과 조회 |
+| POST | `/search` | RAG 의미 검색 (자연어 → 유사 리뷰) |
+| GET | `/trends?period=weekly` | 트렌드/이상 탐지 데이터 |
+| GET | `/report/pdf?analysis_id=N` | PDF 리포트 다운로드 |
+| GET | `/settings` | 자동 분석 설정 조회 |
+| PUT | `/settings` | 자동 분석 설정 변경 |
+
+### 5.1 SSE 진행률 payload
+
+```
+// /embed/stream 예시
+data: {"progress": 23, "message": "100/437 처리 중", "embedded": 100}
+
+// /analyze/stream 예시
+data: {"progress": 0, "message": "전체 9970건 중 200건 샘플링 → 분석 시작"}
+data: {"progress": 25, "message": "배치 1/4 완료", "batch_result": {...}}
+...
+data: {"progress": 100, "done": true}
+```
+
+EventSource 소비는 `frontend/src/hooks/useReviewAnalysis.ts` 에 있다.
 
 ---
 
@@ -462,15 +506,42 @@ LLM은 항상 완벽한 JSON을 반환하지 않으므로:
 
 ---
 
-## 9. 미구현 항목 (추후 작업)
+## 9. 미구현 항목 / 아카이브 Gap 후속 조치 (2026-04-23)
+
+<!-- Code Sync: 2026-04-23 -->
+
+### 9.1 미구현 — Phase 2 연기
+
+아카이브 설계 문서(`docs/archive/2026-04/farmos_review_analysis/farmos_review_analysis.design.md` §4.3, §4.4) 의 Gap G-01 ~ G-03 에 해당하는 항목은 모두 "Phase 2 연기" 로 관리된다. 현재 코드에는 구조만 있고 활성화되지 않음.
+
+| # | 항목 | 현재 상태 | 차단 원인 | 연기 사유 |
+|---|------|----------|----------|----------|
+| G-01 | **멀티테넌트 — 판매자 상품 필터** | 헬퍼 `_get_seller_product_ids()` 구조 있음 (`api/review_analysis.py:69-98`), 실제 호출 없음 | `shop_stores.owner_id` 컬럼 미존재 (주석 TODO) | owner_id 스키마 추가가 쇼핑몰 기능 범위에 포함 |
+| G-02 | **RAG 필터 메서드 `get_reviews_by_products()`** | 미구현 | G-01 에 의존 | G-01 선행 필요 |
+| G-03 | **자동 배치 스케줄러 (`core/review_scheduler.py`)** | 파일 없음. `POST /analyze` 수동 트리거 전용. | 비즈니스 판단 우선순위 낮음 | 현재 UI 수동 실행 + SSE 진행률로 UX 충분 |
+
+### 9.2 기타 미구현 (우선순위 Low)
 
 | 항목 | 우선순위 | 설명 |
 |------|:--------:|------|
-| SC-02 런타임 검증 | Medium | Ollama 실행 후 감성분석 정확도 80%+ 측정 |
-| 자동 배치 스케줄러 | Low | APScheduler 또는 BackgroundTasks로 주기적 자동 분석 |
-| `GET /analysis/{id}` | Low | 특정 분석 ID로 조회 (현재 최신만) |
-| DB 리뷰 연동 | Future | Mock → shop_reviews 테이블 직접 조회로 전환 |
-| 다국어 리뷰 분석 | Future | 영문 리뷰 지원 (ChromaDB 임베딩은 다국어 지원) |
+| SC-02 런타임 검증 | Medium | Ollama 실행 후 감성분석 정확도 80%+ 측정 (일부 수동 검증만 완료) |
+| `GET /analysis/{id}` | Low | 특정 분석 ID로 조회 (현재 최신만 `/analysis` 노출) |
+| 다국어 리뷰 분석 | Future | 영문 리뷰 지원 (Voyage v3.5 는 다국어 지원이므로 분석 LLM 프롬프트만 확장하면 됨) |
+
+### 9.3 완료 (본 문서 2026-04-10 작성 당시 미구현으로 기록됐던 항목)
+
+| 항목 | 완료 시점 | 비고 |
+|------|-----------|------|
+| DB 리뷰 연동 (Mock → shop_reviews 실연동) | 2026-04-* | `ReviewRAG.sync_from_db()`, `sync_from_db_chunked()` 구현 완료. 9,970건 seed. |
+| 임베딩 품질 (한국어) | 2026-04-23 | Voyage v3.5 1024-dim 으로 마이그레이션 완료. |
+
+### 9.4 에러 처리 및 재시도 정책
+
+| 계층 | 정책 |
+|------|------|
+| LLM 응답 파싱 | 3단계 전략: (1) 직접 `json.loads` → (2) ` ```json ... ``` ` 블록 추출 → (3) 첫 `{` ~ 마지막 `}` 구간 추출. 실패 시 최대 **2회 재시도** (`REVIEW_ANALYSIS_MAX_RETRIES=2`). 재시도 소진 시 partial 결과 반환 (`review_analyzer.py`). |
+| 임베딩 배치 실패 | 현재 배치 단위 rollback. 영벡터 합성 금지(컬렉션 오염 방지). 호출자에게 예외 전파 (`review_rag.py:106-110`). |
+| DB 동기화 | `sync_from_db_chunked` 는 LIMIT/OFFSET 페이지네이션 + 중복 제거 (`review_rag.py:423+`). |
 
 ---
 


### PR DESCRIPTION
## 변경 요약
- 상품 리뷰 자동화의 OpenRouter를 통한 LLM 모델 사용을 LiteLLM Proxy 서버를 경유한 API키로 변경
- 임베딩 모델을 BGE-m5 -> VOYOGE 3.5 API를 통한 임베딩.

## 관련 이슈
- Closes #

## 변경 내용
- 상품 리뷰 자동화의 OpenRouter를 통한 LLM 모델 사용을 LiteLLM Proxy 서버를 경유한 API키로 변경
- 임베딩 모델을 BGE-m5 -> VOYOGE 3.5 API를 통한 임베딩.

## 테스트
- [X] 로컬 실행 (백엔드)
- [X] 로컬 실행 (프론트)
- [X] 주요 시나리오 확인:
  - 임베딩 + AI 리뷰 분석기능 테스트 완료.

## 스크린샷/녹화(선택)
- 

## 체크리스트
- [X] 영향 범위(사용자/권한/성능/보안) 검토
- [X] 실패 시 롤백/대안 고려(필요 시)
- [X] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 임베딩 시스템 개선 및 검색 결과에서 중복 항목 제거
  * 추론 강도 설정 기능 추가

* **버그 수정**
  * LLM 호출 시 네트워크 오류에 대한 재시도 및 로깅 처리 개선

* **설정 변경**
  * 기본 LLM 모델을 GPT-5 Nano로 업데이트
  * API 응답 타임아웃 120초로 증가
  * LiteLLM 프록시 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->