### PR TITLE
feat: 통합 영농일지 편집 모달 모바일 UX 개선 및 이전 기록 뷰 분리

### DIFF
--- a/frontend/src/modules/journal/DailyJournalEditor.tsx
+++ b/frontend/src/modules/journal/DailyJournalEditor.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef } from "react";
-import { MdClose, MdAutorenew, MdSave, MdHistory } from "react-icons/md";
+import {
+  MdClose,
+  MdAutorenew,
+  MdSave,
+  MdHistory,
+  MdChevronLeft,
+} from "react-icons/md";
 import toast from "react-hot-toast";
 import type { DailyJournalAPI, DailyJournalRevisionAPI } from "@/types";
 import { useDailyJournal } from "@/hooks/useDailyJournal";
@@ -28,7 +34,8 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
   const [revisions, setRevisions] = useState<DailyJournalRevisionAPI[] | null>(
     dailyJournal.revisions ?? null,
   );
-  const [showRevisions, setShowRevisions] = useState(false);
+  // 모달 내부 뷰 — 편집 본체 / 이전 기록 전체화면.
+  const [view, setView] = useState<"edit" | "history">("edit");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const locked = dailyJournal.status === "confirmed";
@@ -77,9 +84,7 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
     if (r.ok && r.data) {
       toast.success("본문이 저장되었습니다.");
       onSaved(r.data);
-      // 재진입 대비 revisions refresh
-      const rv = await dj.fetchRevisions(dailyJournal.id);
-      if (rv.ok && rv.data) setRevisions(rv.data);
+      onClose(); // 저장 성공 시 모달 자동 닫기. 다음에 편집 열 때 revisions는 그때 다시 조회.
     } else {
       toast.error(r.error?.message || "저장 실패");
     }
@@ -108,15 +113,16 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
     }
   };
 
-  const loadRevisions = async () => {
+  const openHistory = async () => {
+    // 이미 캐시된 revisions가 있으면 즉시 전환, 없으면 서버 조회 후 전환.
     if (revisions !== null) {
-      setShowRevisions((v) => !v);
+      setView("history");
       return;
     }
     const r = await dj.fetchRevisions(dailyJournal.id);
     if (r.ok && r.data) {
       setRevisions(r.data);
-      setShowRevisions(true);
+      setView("history");
     } else {
       toast.error(r.error?.message || "히스토리 조회 실패");
     }
@@ -126,6 +132,7 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
     if (locked) return;
     if (dirty && !confirm("현재 편집 내용이 덮어써집니다. 계속할까요?")) return;
     setNarrative(rev.narrative);
+    setView("edit"); // 불러온 뒤 편집 뷰로 자동 복귀
     toast.success("히스토리 본문을 불러왔습니다. (아직 저장되지 않음)");
   };
 
@@ -140,22 +147,48 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
     >
       <div onClick={handleClose} className="absolute inset-0 bg-black/40" />
 
-      <div className="relative bg-white rounded-2xl shadow-xl w-[95vw] max-w-5xl max-h-[90vh] flex flex-col">
+      <div className="relative bg-white rounded-2xl shadow-xl w-[95vw] max-w-5xl h-[90vh] flex flex-col">
         {/* 헤더 */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-          <div>
-            <h3
-              id="daily-journal-editor-title"
-              className="text-base font-semibold text-gray-900"
-            >
-              통합 영농일지 편집 · {dailyJournal.work_date}
-            </h3>
-            {locked && (
-              <p className="text-xs text-red-500 mt-1">
-                확정된 일지는 편집할 수 없습니다. 먼저 확정을 해제하세요.
-              </p>
+          <div className="flex items-center gap-2">
+            {view === "history" && (
+              <button
+                type="button"
+                onClick={() => setView("edit")}
+                className="p-1 text-gray-500 hover:text-gray-700 cursor-pointer"
+                aria-label="편집 뷰로 돌아가기"
+              >
+                <MdChevronLeft className="text-xl" />
+              </button>
             )}
+            <div>
+              <h3
+                id="daily-journal-editor-title"
+                className="text-base font-semibold text-gray-900"
+              >
+                {view === "edit"
+                  ? `통합 영농일지 편집 · ${dailyJournal.work_date}`
+                  : `이전 기록 (${revisions?.length ?? 0}건)`}
+              </h3>
+              {view === "edit" && locked && (
+                <p className="text-xs text-red-500 mt-1">
+                  확정된 일지는 편집할 수 없습니다. 먼저 확정을 해제하세요.
+                </p>
+              )}
+            </div>
           </div>
+          <div className="flex items-center gap-1">
+            {view === "edit" && (
+              <button
+                type="button"
+                onClick={openHistory}
+                aria-label="이전 기록"
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs text-indigo-600 hover:bg-indigo-50 cursor-pointer"
+              >
+                <MdHistory className="text-base" />
+                <span className="hidden sm:inline">이전 기록</span>
+              </button>
+            )}
           <button
             onClick={handleClose}
             className="p-1 text-gray-400 hover:text-gray-600 cursor-pointer"
@@ -163,12 +196,14 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
           >
             <MdClose className="text-xl" />
           </button>
+          </div>
         </div>
 
-        {/* 본문 영역 */}
+        {/* 본문 영역 — view 상태에 따라 편집 뷰 또는 이전 기록 뷰 */}
+        {view === "edit" && (
         <div className="flex-1 overflow-hidden flex flex-col md:flex-row">
-          {/* 좌측: 원본 참고 */}
-          <aside className="md:w-72 md:border-r border-gray-100 overflow-y-auto p-4 bg-gray-50/50">
+          {/* 좌측 원본 참고 — 데스크톱 전용. 모바일은 공간 확보를 위해 숨김. */}
+          <aside className="hidden md:flex md:flex-col md:w-72 md:border-r border-gray-100 md:overflow-y-auto md:p-4 bg-gray-50/50">
             <h4 className="text-xs font-semibold text-gray-500 mb-2">
               원본 작업 기록 ({snapshot.length}건)
             </h4>
@@ -200,51 +235,6 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
                 <li className="text-gray-400">원본 스냅샷이 없습니다.</li>
               )}
             </ul>
-
-            {/* 편집 히스토리 */}
-            <div className="mt-4">
-              <button
-                type="button"
-                onClick={loadRevisions}
-                className="text-xs text-indigo-600 hover:text-indigo-800 flex items-center gap-1 cursor-pointer"
-              >
-                <MdHistory />
-                {showRevisions ? "히스토리 숨기기" : "편집 히스토리 보기"}
-              </button>
-              {showRevisions && revisions && (
-                <ul className="mt-2 space-y-2 text-xs">
-                  {revisions.length === 0 && (
-                    <li className="text-gray-400">히스토리 없음</li>
-                  )}
-                  {revisions.map((rev) => (
-                    <li
-                      key={rev.id}
-                      className="p-2 bg-white border border-gray-100 rounded"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="text-gray-500">
-                          {new Date(rev.created_at).toLocaleString("ko-KR")}
-                        </span>
-                        {!locked && (
-                          <button
-                            type="button"
-                            onClick={() => restoreFromRevision(rev)}
-                            className="text-indigo-600 hover:text-indigo-800 cursor-pointer"
-                          >
-                            이 본문 불러오기
-                          </button>
-                        )}
-                      </div>
-                      <div className="text-gray-400 line-clamp-2 mt-1">
-                        {rev.narrative.length > 80
-                          ? `${rev.narrative.slice(0, 80)}…`
-                          : rev.narrative}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
           </aside>
 
           {/* 우측: 본문 편집 */}
@@ -266,8 +256,50 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
             </div>
           </div>
         </div>
+        )}
 
-        {/* 푸터 */}
+        {/* 이전 기록 뷰 — 모달 전체 화면을 revision 카드 리스트로 전환 */}
+        {view === "history" && (
+          <div className="flex-1 overflow-y-auto px-4 py-4 bg-gray-50/30">
+            {revisions && revisions.length === 0 && (
+              <div className="text-center py-12 text-sm text-gray-400">
+                아직 편집 히스토리가 없습니다.
+              </div>
+            )}
+            {!locked && (
+              <p className="text-xs text-gray-500 mb-3 text-center">
+                불러올 기록을 선택하세요. 현재 편집 중인 내용은 덮어써집니다.
+              </p>
+            )}
+            <ul className="space-y-3">
+              {revisions?.map((rev) => (
+                <li key={rev.id}>
+                  <button
+                    type="button"
+                    onClick={() => restoreFromRevision(rev)}
+                    disabled={locked}
+                    className="w-full text-left p-4 bg-white border border-gray-200 rounded-xl shadow-sm hover:border-indigo-400 hover:shadow-md active:scale-[0.99] transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-gray-200 disabled:hover:shadow-sm disabled:active:scale-100"
+                  >
+                    <div className="flex items-center gap-2 text-xs mb-2">
+                      <span className="text-gray-500">
+                        {new Date(rev.created_at).toLocaleString("ko-KR")}
+                      </span>
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 font-medium">
+                        {rev.narrative_source}
+                      </span>
+                    </div>
+                    <pre className="whitespace-pre-wrap font-sans text-sm text-gray-700 leading-relaxed line-clamp-6">
+                      {rev.narrative}
+                    </pre>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* 푸터 — 편집 뷰에서만 표시 */}
+        {view === "edit" && (
         <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-gray-100 bg-gray-50/50">
           <button
             onClick={handleClose}
@@ -294,6 +326,7 @@ export default function DailyJournalEditor({ dailyJournal, onSaved, onClose }: P
             {busy === "save" ? "저장 중..." : "저장"}
           </button>
         </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 변경 요약
- 머지된 통합 영농일지 편집 모달의 모바일 UX를 집중 개선
- "이전 기록(revisions)" 섹션을 aside 드롭다운에서 **전체 뷰 전환 방식**으로 재설계
- 저장 완료 시 모달 자동 닫기

## 변경 내용

### 버그 수정
- 히스토리 revision 카드의 [불러오기] 버튼이 모바일에서 클릭되지 않던 문제
  → 카드 전체를 `<button>`으로 감싸 클릭 타겟 확장

### UX 개선
- 모달 높이 `max-h-[90vh]` → `h-[90vh]` (내용 적어도 유지)
- `view: "edit" | "history"` 상태로 모달 내부 뷰 분리
- 헤더 우측 [🕒 이전 기록] 버튼 / 히스토리 뷰 상단 [← 뒤로] 버튼
- 모바일에서 좌측 원본 작업 기록 aside를 숨김(`hidden md:flex`) → textarea 공간 확보
- 히스토리 카드 탭 → 본문 복원 + 편집 뷰 자동 복귀
- 저장 성공 시 모달 자동 닫기

### 정리
- `showRevisions` / `showAsideMobile` state 제거
- 불필요한 `MdExpandMore`, `MdExpandLess` import 제거

## 테스트
- [x] 로컬 실행 (프론트)
- [x] 주요 시나리오 확인:
  - 모바일 뷰: textarea 공간 풍부, 히스토리 카드 클릭으로 복원 ✓
  - 데스크톱 뷰: 좌측 aside 원본 작업 기록 정상 표시 ✓
  - 저장 시 모달 자동 닫힘 + Panel 즉시 갱신 ✓
  - 재생성은 모달 유지 (결과 바로 확인용) ✓

## 체크리스트
- [x] 영향 범위 검토 — `DailyJournalEditor.tsx` 한 파일만 수정, 공개 prop 시그니처 동일
- [x] 실패 시 롤백 — 단일 파일이라 revert 즉시 가능
- [x] 문서/환경변수/마이그레이션 — 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 저널 편집기에서 편집 보기와 수정 이력 보기 간 개선된 네비게이션 추가
  * 수정된 버전 복원 기능 강화

* **개선 사항**
  * 저널 저장 시 모달이 즉시 종료되어 더 빠른 사용자 경험 제공
  * 수정 이력 로딩 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->