### PR TITLE
Qwen Pod 연결

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,6 +76,12 @@ LLM_REASONING_EFFORT=minimal
 REVIEW_ANALYSIS_BATCH_SIZE=40
 REVIEW_ANALYSIS_MAX_RETRIES=2
 
+# ── 해충 이미지 분류 (RunPod) ────────────────────────────────────────────
+# pest-detector-deploy (Qwen3.5-9B + LoRA) 서버 — POST /classify multipart
+# 예: https://3c550i03u5bu0h-8888.proxy.runpod.net  (끝에 슬래시 없이)
+# 미설정 시 /diagnosis/upload 는 pest 없이 image_url 만 반환 (graceful degrade)
+PEST_CLASSIFIER_URL=https://3c550i03u5bu0h-8888.proxy.runpod.net
+
 # ── AI Agent (IoT 제어) ──────────────────────────────────────────────────
 AI_AGENT_MODEL=openai/gpt-5-mini
 AI_AGENT_LLM_INTERVAL=300

--- a/backend/app/api/diagnosis.py
+++ b/backend/app/api/diagnosis.py
@@ -22,6 +22,11 @@ from app.models.user import User
 from app.core.config import settings
 
 from app.services.diagnosis_agent import run_diagnosis
+from app.services.pest_classifier import (
+    classify_pest_image,
+    ClassifierError,
+    ConfigurationError as ClassifierConfigError,
+)
 
 from pydantic import BaseModel, Field
 
@@ -77,10 +82,26 @@ async def upload_diagnosis_image(
                 image = await asyncio.to_thread(image.convert, "RGB")
                 
             await asyncio.to_thread(image.save, file_path, "WEBP", quality=85)
-            
-            # 5. 접근 가능한 URL 반환
+
+            # 5. 해충 분류 (RunPod 서버) — 실패해도 image_url 은 정상 반환 (graceful degrade)
+            #    프론트엔드는 pest 가 없으면 testPest 로 폴백한다.
             image_url = f"/uploads/diagnosis/{file_id}.webp"
-            return {"image_url": image_url}
+            response: dict = {"image_url": image_url}
+            try:
+                result = await classify_pest_image(
+                    contents,
+                    filename=file.filename or "image.jpg",
+                    content_type=file.content_type or "image/jpeg",
+                )
+                response["pest"] = result.get("pred")
+                response["pest_raw"] = result.get("raw")
+                response["pest_elapsed_s"] = result.get("elapsed_s")
+            except ClassifierConfigError:
+                logger.info("PEST_CLASSIFIER_URL 미설정 — pest 자동분류 건너뜀")
+            except ClassifierError:
+                logger.exception("pest 자동분류 실패 (image_url=%s) — 폴백 진행", image_url)
+
+            return response
 
         except Image.DecompressionBombError:
             raise HTTPException(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,11 @@ class Settings(BaseSettings):
     REVIEW_ANALYSIS_BATCH_SIZE: int = 40
     REVIEW_ANALYSIS_MAX_RETRIES: int = 2
 
+    # 해충 이미지 분류 서버 (RunPod 에 배포된 pest-detector-deploy)
+    # 예: https://<POD_ID>-<PORT>.proxy.runpod.net  (끝에 슬래시 없이)
+    # 비워두면 /diagnosis/upload 가 pest 필드 없이 image_url 만 반환한다.
+    PEST_CLASSIFIER_URL: str = ""
+
     # ── AI Agent (IoT 제어) ──────────────────────────────────────────────────
     AI_AGENT_MODEL: str = ""
     AI_AGENT_LLM_INTERVAL: int = 300

--- a/backend/app/services/pest_classifier.py
+++ b/backend/app/services/pest_classifier.py
@@ -1,0 +1,77 @@
+"""해충 이미지 분류 서비스 — RunPod 에 배포된 pest-detector-deploy 서버 호출.
+
+서버 측 엔드포인트 (deploy/server.py):
+    POST /classify      multipart file=...
+응답: {"pred": "<한국어 클래스>", "raw": "<원본>", "elapsed_s": float}
+
+PEST_CLASSIFIER_URL 미설정 시 ConfigurationError, 호출 실패 시 ClassifierError.
+"""
+import logging
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class ClassifierError(Exception):
+    """분류 서버 호출 실패 (네트워크·타임아웃·HTTP 에러)."""
+
+
+class ConfigurationError(Exception):
+    """PEST_CLASSIFIER_URL 미설정."""
+
+
+async def classify_pest_image(
+    image_bytes: bytes,
+    filename: str = "image.jpg",
+    content_type: str = "image/jpeg",
+) -> dict:
+    """이미지 바이트를 분류 서버로 전송하고 예측 결과를 돌려준다.
+
+    반환값: {"pred": str, "raw": str, "elapsed_s": float}
+    """
+    base_url = (settings.PEST_CLASSIFIER_URL or "").rstrip("/")
+    if not base_url:
+        raise ConfigurationError("PEST_CLASSIFIER_URL 이 설정되지 않았습니다.")
+
+    timeout = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
+    async with httpx.AsyncClient(http1=True, http2=False, timeout=timeout) as client:
+        try:
+            resp = await client.post(
+                f"{base_url}/classify",
+                files={"file": (filename, image_bytes, content_type)},
+            )
+        except httpx.HTTPError as e:
+            logger.exception("분류 서버 호출 실패: %s", base_url)
+            raise ClassifierError(f"분류 서버 통신 오류: {e}") from e
+
+    if resp.status_code != 200:
+        body = resp.text[:200]
+        logger.error("분류 서버 비정상 응답 %s: %s", resp.status_code, body)
+        raise ClassifierError(f"분류 서버 오류 ({resp.status_code}): {body}")
+
+    try:
+        data = resp.json()
+    except ValueError as e:
+        raise ClassifierError(f"분류 서버 응답 파싱 실패: {e}") from e
+
+    if "pred" not in data:
+        raise ClassifierError(f"예상치 못한 응답 형식: {data}")
+    return data
+
+
+async def classifier_health() -> Optional[dict]:
+    """분류 서버 헬스 체크. URL 미설정이면 None."""
+    base_url = (settings.PEST_CLASSIFIER_URL or "").rstrip("/")
+    if not base_url:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{base_url}/health")
+            return resp.json() if resp.status_code == 200 else None
+    except httpx.HTTPError:
+        return None

--- a/frontend/src/modules/diagnosis/DiagnosisPage.tsx
+++ b/frontend/src/modules/diagnosis/DiagnosisPage.tsx
@@ -17,12 +17,14 @@ const CROPS = [
   "감자", "고추", "들깨", "무", "배추", "벼", "양배추", "오이", "옥수수", "콩", "토마토", "파"
 ];
 
+// 모델의 분류 어휘 (WizWix/kor-pest-detector evaluation/metrics.json) 와 1:1 정렬.
+// "정상" 은 UX 편의상 맨 앞으로 호이스트, 나머지 19종 해충은 한글 사전순.
 const PESTS = [
   "정상", "검거세미밤나방", "꽃노랑총채벌레", "담배가루이", "담배거세미나방",
   "담배나방", "도둑나방", "먹노린재", "목화바둑명나방", "무잎벌",
   "배추좀나방", "배추흰나비", "벼룩잎벌레", "복숭아혹진딧물",
-  "비단노린재", "썩덩나무노린재", "열대거세미나방", "큰28점박이무당벌레",
-  "톱다리개미허리노린재", "파밤나방"
+  "썩덩나무노린재", "열대거세미나방", "큰28점박이무당벌레",
+  "톱다리개미허리노린재", "파밤나방", "홍비단노린재"
 ];
 
 const API_BASE = 'http://localhost:8000/api/v1/diagnosis';
@@ -193,10 +195,10 @@ export default function DiagnosisPage() {
     }
   };
 
-  const uploadImage = async (file: File, signal?: AbortSignal) => {
+  const uploadImage = async (file: File, signal?: AbortSignal): Promise<{ image_url: string; pest?: string }> => {
     const formData = new FormData();
     formData.append('file', file);
-    
+
     try {
       const res = await fetch(`${API_BASE}/upload`, {
         method: 'POST',
@@ -204,10 +206,10 @@ export default function DiagnosisPage() {
         credentials: 'include',
         signal,
       });
-      
+
       if (!res.ok) throw new Error('이미지 업로드에 실패했습니다.');
       const data = await res.json();
-      return data.image_url;
+      return { image_url: data.image_url, pest: data.pest };
     } catch (error) {
       console.error("Upload error:", error);
       throw error;
@@ -233,21 +235,29 @@ export default function DiagnosisPage() {
     abortControllerRef.current = controller;
 
     try {
-      let imageUrl = null;
+      let imageUrl: string | null = null;
+      let detectedPest: string | undefined;
       const file = fileToUpload || selectedFile;
       if (file) {
         setLoadingMessage("이미지 고해상도 분석 및 최적화 중...");
-        imageUrl = await uploadImage(file, controller.signal);
+        const uploadResult = await uploadImage(file, controller.signal);
+        imageUrl = uploadResult.image_url;
+        detectedPest = uploadResult.pest;
       }
 
-      if (!isTest) {
-        toast('현재 이미지 자동 판독(VLM) 연동 전입니다. 선택된 해충으로 임시 진단합니다.', {
+      // VLM 자동 판독 결과가 있으면 사용, 없으면 (테스트 모드 또는 분류 서버 미가용) testPest 로 폴백
+      const pestToUse = (!isTest && detectedPest) ? detectedPest : testPest;
+
+      if (!isTest && !detectedPest) {
+        toast('VLM 자동 판독 서버에 연결할 수 없어 선택된 해충으로 임시 진단합니다.', {
           icon: '⚠️'
         });
+      } else if (!isTest && detectedPest) {
+        toast.success(`AI 판독: ${detectedPest}`, { icon: '🤖' });
       }
 
       const payload = {
-        pest: testPest,
+        pest: pestToUse,
         crop: selectedCrop || "배추",
         region: selectedRegion || "서울",
         image_url: imageUrl


### PR DESCRIPTION
## 변경 요약
- RunPod 에 배포된 해충 분류 서버(WizWix/kor-pest-detector LoRA + Qwen3.5-9B)를 FarmOS-v2 진단 플로우에 연결.
- 기존 `POST /diagnosis/upload` 엔드포인트에 분류 호출을 합치는 방식으로 통합 — 신규 엔드포인트 없이 1회 라운드트립으로 이미지 저장 + 해충 자동 판독을 모두 수행.
- 분류 서버가 꺼져 있거나 미설정인 경우 graceful degrade — 업로드는 정상 처리되고 프론트는 기존 수동 선택(testPest) 경로로 폴백.

## 관련 이슈
- Closes #(이슈 번호)

## 변경 내용

### 백엔드 (`backend/`)
- **NEW** `app/services/pest_classifier.py`
  - `classify_pest_image(bytes) -> {pred, raw, elapsed_s}` — httpx 비동기 클라이언트로 RunPod `/classify` 호출.
  - `ClassifierError` / `ConfigurationError` 예외로 실패 모드를 명확히 구분.
- **EDIT** `app/core/config.py`
  - `PEST_CLASSIFIER_URL: str = ""` 추가. 빈 문자열이면 자동 분류 비활성화.
- **EDIT** `app/api/diagnosis.py`
  - 기존 `POST /diagnosis/upload` 가 WebP 저장 후 분류 서버를 호출하도록 확장.
  - 성공 시 응답: `{image_url, pest, pest_raw, pest_elapsed_s}`
  - 실패 시 응답: `{image_url}` (pest 필드 없음 → 프론트가 폴백 처리)
  - 분류 실패는 `logger.exception` 으로 기록되지만 업로드 자체는 200 으로 정상 반환.
- **EDIT** `.env.example`
  - `PEST_CLASSIFIER_URL=https://3c550i03u5bu0h-8888.proxy.runpod.net` 기본값 추가.

### 프론트엔드 (`frontend/src/modules/diagnosis/DiagnosisPage.tsx`)
- `uploadImage()` 반환 타입을 `{ image_url, pest? }` 로 확장 (기존: 문자열).
- `startDiagnosis()` 가 자동 판독 결과(`detectedPest`)가 있으면 우선 사용, 없으면 기존 수동 선택값(`testPest`) 으로 폴백.
- 토스트 메시지 분기:
  - 자동 판독 성공: `AI 판독: <해충명>` (success)
  - 자동 판독 실패: `VLM 자동 판독 서버에 연결할 수 없어 선택된 해충으로 임시 진단합니다.` (warning)
- `PESTS` 드롭다운 어휘를 WizWix 모델의 `/classes` 응답(20개) 과 1:1 정렬:
  - 추가: `홍비단노린재`
  - 제거: `비단노린재` (모델 어휘에 없음)
  - 정렬: `정상` 을 맨 앞, 나머지 19종 한글 사전순.

## 테스트
- [ㅇ] 로컬 실행 (백엔드)
- [ㅇ] 로컬 실행 (프론트)
- [ㅇ] 주요 시나리오 확인:
  - 분류 서버 ON: 이미지 업로드 시 자동 판독 결과가 토스트로 표시되고, 그 결과로 `/diagnosis/history` 가 생성됨
  - 분류 서버 OFF: 약 400ms 내에 RunPod 프록시 404 반환 → 업로드는 성공, 경고 토스트 표시 후 수동 선택값으로 진단 진행
  - `PEST_CLASSIFIER_URL` 미설정: 자동 분류 건너뜀, 기존 수동 플로우와 동일 동작
  - "정상" 결과 처리: 모델이 `정상` 을 반환하면 기존 `if pest == "정상"` 패스트트랙(LLM 워크플로우 스킵) 자동 진입
  - "임시 VLM 진단 테스트" 버튼: 변경 없이 기존 수동 진단 그대로 동작
  - 프론트 드롭다운 ↔ 모델 `/classes` 셋 동등성: `assert sorted(PESTS \ {"정상"}) == sorted(model_classes \ {"정상"})` 통과

<img width="966" height="468" alt="image" src="https://github.com/user-attachments/assets/50de389d-52b9-4488-840f-5037d3117c7e" />

## 체크리스트
-  영향 범위(사용자/권한/성능/보안) 검토
  - 사용자: 진단 페이지 UX 만 영향 (업로드 → 자동 판독 → 결과). 기타 모듈 영향 없음.
  - 권한: 신규 권한 없음. 기존 `get_current_user` 인증 그대로 사용.
  - 성능: `/upload` 1회 호출 안에 분류까지 끝남 → 추가 라운드트립 없음. 분류 호출은 평균 약 2초(JIT 재컴파일 후), 첫 호출 약 10초.
  - 보안: 업로드 크기 10MB 상한 / 24MP 픽셀 상한 기존 정책 유지. 분류 서버 호출 시 multipart 로 원본 바이트만 전송, 별도 토큰/PII 노출 없음.
- [o] 실패 시 롤백/대안 고려
  - 분류 서버 장애 → fail-soft 로 자동 처리, 사용자 동작 차단 없음.
  - `.env` 의 `PEST_CLASSIFIER_URL` 을 빈 문자열로 두면 분류 호출이 즉시 비활성화 (코드 변경 불필요).
  - 어댑터 교체 시: `restart_server.sh` 의 `ADAPTER` 환경변수와 `server.py` / 프론트 `PESTS` 의 어휘만 동기화하면 됨.
- [o] 문서/환경변수/마이그레이션 변경 사항 반영
  - `.env.example` 업데이트.
  - DB 스키마 변경 없음 (기존 `image_url` / `pest` 컬럼 그대로 사용).
  - 마이그레이션 불필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 이미지 업로드 시 해충을 자동으로 감지하고 분류하는 기능 추가
  * 감지된 해충에 대한 실시간 피드백 및 알림 개선
  * 새로운 해충 타입 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->