### PR TITLE
fix: ChatOpenAI 파라미터 수정

### DIFF
--- a/backend/app/api/diagnosis.py
+++ b/backend/app/api/diagnosis.py
@@ -320,13 +320,8 @@ async def add_chat_message(
                         base_url=settings.LITELLM_URL,
                         temperature=0.0,
                         http_async_client=custom_async_client,
-                        model_kwargs={
-                            "extra_body": {
-                                "reasoning": {
-                                    "effort": "minimal",
-                                    "exclude": True
-                                }
-                            }
+                        extra_body={
+                            "reasoning": {"effort": "minimal", "exclude": True}
                         }
                     )
                     

--- a/backend/app/api/subsidy.py
+++ b/backend/app/api/subsidy.py
@@ -158,7 +158,7 @@ async def _call_llm(system_prompt: str, user_prompt: str) -> str:
     diagnosis.py 와 동일한 컨벤션:
       - settings.LITELLM_API_KEY / settings.LITELLM_URL 사용
       - async with httpx.AsyncClient 로 커넥션 누수 방지
-      - model_kwargs.extra_body.reasoning.exclude=True 로 reasoning 토큰 출력 제외
+      - extra_body.reasoning.exclude=True 로 reasoning 토큰 출력 제외
 
     속도 튜닝:
       - max_tokens=500: 장문 답변의 꼬리 지연 제거 (시행지침 Q&A 는 3~5 문장이면 충분)
@@ -182,11 +182,7 @@ async def _call_llm(system_prompt: str, user_prompt: str) -> str:
             temperature=0.2,
             max_tokens=500,
             http_async_client=http_client,
-            model_kwargs={
-                "extra_body": {
-                    "reasoning": {"effort": "minimal", "exclude": True}
-                }
-            },
+            extra_body={"reasoning": {"effort": "minimal", "exclude": True}},
         )
         response = await llm.ainvoke([
             SystemMessage(content=system_prompt),

--- a/backend/app/services/diagnosis_agent.py
+++ b/backend/app/services/diagnosis_agent.py
@@ -588,11 +588,7 @@ async def generate_diagnosis(state: DiagnosisState) -> dict:
             llm_standard = ChatOpenAI(
                 model=model_name, api_key=api_key, base_url=settings.LITELLM_URL, temperature=0.0,
                 http_async_client=custom_async_client,
-                model_kwargs={
-                    "extra_body": {
-                        "reasoning": {"effort": "minimal", "exclude": True}
-                    }
-                }
+                extra_body={"reasoning": {"effort": "minimal", "exclude": True}}
             )
 
             chain = prompt | llm_standard | StrOutputParser()


### PR DESCRIPTION
## 변경 요약
- `model_kwargs.extra_body` 대신 `extra_body` 사용

## NOTE

프로젝트 전체에 대한 Reformat이 필요해 보입니다. 일부 생성 AI가 Code Convention을 따르지 않는 것으로 보입니다.