### PR TITLE
[FIX] 쇼핑몰 쿠키 설정 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,7 +22,14 @@ JWT_SECRET_KEY=
 
 # 쿠키 보안 — 운영 환경(HTTPS)에서는 반드시 true
 # 로컬 HTTP 개발: false / 운영 배포: true
-COOKIE_SECURE=false
+COOKIE_SECURE=true
+
+# 서브도메인 간 쿠키 공유 — 운영 배포 시 반드시 설정
+# app.farmos.biz 에서 로그인 후 shop.farmos.biz 에서도 인증이 유지되려면
+# farmos_token 쿠키가 .farmos.biz 도메인으로 설정되어야 한다.
+# 미설정(기본값 빈 문자열)이면 host-only 쿠키 → 서브도메인 간 공유 불가 → 챗봇 인증 실패.
+# 로컬 개발: 빈 값 / 운영 배포: .farmos.biz (앞에 점 포함)
+COOKIE_DOMAIN=.farmos.biz
 
 # 비밀번호 재설정 이메일 발송 — 이메일 인프라 구축 후 true 로 활성화.
 # false 인 동안 /find-password 응답에 토큰을 포함하지 않음 (보안).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# ── 외부 서비스 URL ──────────────────────────────────────────────────────
+# 쇼핑몰 프론트엔드 URL — 로그인 후 ?redirect 파라미터 검증에 사용
+# 이 값과 동일한 origin 의 redirect 만 허용 (오픈 리디렉트 방지)
+# 로컬: http://localhost:5174 / 운영: https://shop.farmos.biz
+VITE_SHOP_URL=https://shop.farmos.biz

--- a/frontend/src/modules/auth/LoginPage.tsx
+++ b/frontend/src/modules/auth/LoginPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/context/AuthContext';
 import { Spinner } from '@/components/ui';
+
+const ALLOWED_SHOP_ORIGIN = import.meta.env.VITE_SHOP_URL ?? 'https://shop.farmos.biz';
 
 function LeafMark({ className = '' }: { className?: string }) {
   return (
@@ -16,6 +18,7 @@ function LeafMark({ className = '' }: { className?: string }) {
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { login } = useAuth();
   const [userId, setUserId] = useState('');
   const [password, setPassword] = useState('');
@@ -36,6 +39,19 @@ export default function LoginPage() {
     try {
       await login(userId, password);
       toast.success('환영합니다!');
+      const redirectParam = searchParams.get('redirect');
+      if (redirectParam) {
+        try {
+          const redirectUrl = new URL(redirectParam);
+          const allowedUrl = new URL(ALLOWED_SHOP_ORIGIN);
+          if (redirectUrl.origin === allowedUrl.origin) {
+            window.location.href = redirectParam;
+            return;
+          }
+        } catch {
+          // 잘못된 URL이면 기본 이동
+        }
+      }
       navigate('/');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : '로그인에 실패했습니다.');

--- a/shopping_mall/frontend/src/components/common/chat/index.tsx
+++ b/shopping_mall/frontend/src/components/common/chat/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import toast from 'react-hot-toast';
 import { useUserStore } from '@/stores/userStore';
 import { useActiveSession, useCreateSession } from './useChatSession.ts';
 import ChatSessionList from './ChatSessionList.tsx';
@@ -10,7 +11,7 @@ export default function ChatWidget() {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<ChatView>('list');
   const [activeSessionId, setActiveSessionId] = useState<number | null>(null);
-  const { user } = useUserStore();
+  const { user, isLoading: authLoading } = useUserStore();
   const userId = user?.shop_user_id ?? null;
   const wasOpenRef = useRef(false);
   // 위젯이 열릴 때 초기화 의도를 보관 — activeSessionLoading이 true인 동안에도 유지
@@ -44,6 +45,9 @@ export default function ChatWidget() {
           setActiveSessionId(newSession.id);
           setView('chat');
         },
+        onError: () => {
+          toast.error('채팅을 시작할 수 없습니다. 잠시 후 다시 시도해주세요.');
+        },
       });
     }
   }, [open, userId, activeSessionLoading, activeSession, activeSessionId, createSession]);
@@ -53,6 +57,11 @@ export default function ChatWidget() {
     setOpen(false);
     // Keep view and activeSessionId for next open
   };
+
+  // 인증 확인 중에는 GuestChatWidget을 보여주지 않음 (깜빡임 방지)
+  if (authLoading) {
+    return null;
+  }
 
   // 비회원은 GuestChatWidget 사용
   if (!userId) {


### PR DESCRIPTION
## 변경 요약
  - `app.farmos.biz` 로그인 후 `shop.farmos.biz` 챗봇에서 세션이 생성되지 않는 버그 수정

  ## 관련 이슈
  - Closes #

  ## 변경 내용
  - **[FarmOS FE]** `LoginPage`: `?redirect` 쿼리 파라미터 처리 추가
    - 로그인 성공 후 `VITE_SHOP_URL`과 동일한 origin일 때만 해당 URL로 리디렉션 (오픈 리디렉트   
  방지)
    - 미설정 시 기존처럼 FarmOS 루트(`/`)로 이동
  - **[쇼핑몰 FE]** `ChatWidget`: 인증 로딩 중 `GuestChatWidget` 깜빡임 방지 (`authLoading` 체크)
  - **[쇼핑몰 FE]** `ChatWidget`: 세션 생성 실패 시 `toast.error` 노출 (기존엔 무음 실패)        
  - **[FarmOS BE]** `backend/.env.example`: `COOKIE_DOMAIN`, `COOKIE_SECURE` 항목 및 설명 추가   
  - **[FarmOS FE]** `frontend/.env.example`: `VITE_SHOP_URL` 항목 신규 추가

  ## 근본 원인
  `farmos_token` 쿠키가 `COOKIE_DOMAIN` 미설정으로 `app.farmos.biz` host-only 쿠키로 발급되어    
  `shop.farmos.biz` 요청에 포함되지 않음. 챗봇 API는 이 쿠키를 로컬 JWT 디코딩으로 검증하므로    
  쿠키 부재 시 401 반환 → 세션 미생성.

  > **프로덕션 서버 작업 필요**: FarmOS 백엔드 `.env`에 아래 두 줄 추가 후 재시작, 재로그인 필요 
  > ```env
  > COOKIE_DOMAIN=.farmos.biz
  > COOKIE_SECURE=true
  > ```

  ## 테스트
  - [ ] 로컬 실행 (백엔드)
  - [ ] 로컬 실행 (프론트)
  - [ ] 주요 시나리오 확인:
    - `app.farmos.biz/login?redirect=https://shop.farmos.biz` 로그인 → 쇼핑몰로 자동 리디렉션    
    - 쇼핑몰 챗봇 열기 → 채팅 세션 자동 생성 및 채팅 뷰 진입
    - 세션 생성 실패 시 토스트 에러 메시지 노출 확인
    - 악의적인 redirect URL(`https://malicious.com`) 입력 시 FarmOS 루트로 이동 확인

  ## 스크린샷/녹화(선택)
  -

  ## 체크리스트
  - [x] 영향 범위(사용자/권한/성능/보안) 검토
    - 오픈 리디렉트: `new URL()` origin 비교로 허용된 도메인만 리디렉션
    - `COOKIE_SECURE=true` 설정 시 HTTPS 환경에서만 쿠키 전송 (프로덕션 안전)
  - [ ] 실패 시 롤백/대안 고려(필요 시)
  - [x] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)
    - `backend/.env.example`, `frontend/.env.example` 업데이트